### PR TITLE
Changing json version to get gem working on rails 3.1.3

### DIFF
--- a/nexmo.gemspec
+++ b/nexmo.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = 'A simple wrapper for the Nexmo API'
   s.summary = 'See description'
   s.files = Dir.glob('{lib,spec}/**/*') + %w(README.txt nexmo.gemspec)
-  s.add_dependency('json', ['~> 1.5.1'])
+  s.add_dependency('json', ['~> 1.6.0'])
   s.add_development_dependency('mocha')
   s.require_path = 'lib'
 end


### PR DESCRIPTION
I'm using Rails 3.1.3 and json dependency runs in conflict when using nexmo. So I've upgraded to newest version of json in gemspec and it's working now.

Maybe you want to pull this request.
