### PR TITLE
Global auth configuration

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -4,9 +4,23 @@ require 'json'
 require 'uri'
 
 module Nexmo
+  def self.auth=(options)
+    @auth = options
+  end
+
+  def self.auth
+    @auth || {}
+  end
+
+  class InvalidAuthError < RuntimeError
+  end
+
   class Client
-    def initialize(key, secret)
-      @key, @secret = key, secret
+    def initialize(key = nil, secret = nil)
+      @key, @secret = key || Nexmo.auth[:key], secret || Nexmo.auth[:secret]
+      if @key.nil? || @secret.nil?
+        raise Nexmo::InvalidAuthError
+      end
 
       @headers = {'Content-Type' => 'application/x-www-form-urlencoded'}
 

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -16,11 +16,41 @@ describe Nexmo::Client do
     @client.headers.must_be_kind_of(Hash)
   end
 
+  it 'allows to setup auth configuration for all clients' do
+    expected_configs = {key: 'newkey', secret: 'newsecret'}
+    Nexmo.auth = expected_configs
+    assert_equal expected_configs, Nexmo.auth
+  end
+
+  it 'raises error when there is no auth configs for client' do
+    Nexmo.auth = nil
+    assert_raises Nexmo::InvalidAuthError do
+      @client = Nexmo::Client.new
+    end
+  end
+
   describe '#send_message' do
     it 'makes the correct http call' do
       http_response = stub(:body => '{"messages":[{"status":0,"message-id":"id"}]}')
 
       data = 'from=ruby&to=number&text=Hey%21&username=key&password=secret'
+
+      headers = {'Content-Type' => 'application/x-www-form-urlencoded'}
+
+      @client.http.expects(:post).with('/sms/json', data, headers).returns(http_response)
+
+      response = @client.send_message({from: 'ruby', to: 'number', text: 'Hey!'})
+
+      assert response.success?
+    end
+
+    it 'uses auth configs if given' do
+      Nexmo.auth = {key: 'newkey', secret: 'newsecret'}
+      @client = Nexmo::Client.new
+
+      http_response = stub(:body => '{"messages":[{"status":0,"message-id":"id"}]}')
+
+      data = 'from=ruby&to=number&text=Hey%21&username=newkey&password=newsecret'
 
       headers = {'Content-Type' => 'application/x-www-form-urlencoded'}
 


### PR DESCRIPTION
Hey, I did another change that allows to configure auth options once and use it in the Nexmo::Client without passing key and secret every time you want to send a message.

By the way, I didn't removed the option to pass key and secret when generating a new Nexmo::Client.

Hope you like it.
