### PR TITLE
Fix #4 - Rescue from JSON::ParseError

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -19,11 +19,15 @@ module Nexmo
 
     def send_message(data)
       response = @http.post('/sms/json', encode(data), headers)
+      begin
+        object = JSON.parse(response.body)['messages'].first
 
-      object = JSON.parse(response.body)['messages'].first
+        status = object['status'].to_i
+      rescue JSON::ParseError
+        object = {'error-text' => 'Internal error'}
 
-      status = object['status'].to_i
-
+        status = 5
+      end
       if status == 0
         Success.new(object['message-id'])
       else

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -19,15 +19,15 @@ module Nexmo
 
     def send_message(data)
       response = @http.post('/sms/json', encode(data), headers)
+
       begin
         object = JSON.parse(response.body)['messages'].first
-
-        status = object['status'].to_i
-      rescue JSON::ParseError
-        object = {'error-text' => 'Internal error'}
-
-        status = 5
+      rescue JSON::ParserError
+        object = {'status' => '5', 'error-text' => 'Internal error'}
       end
+
+      status = object['status'].to_i
+
       if status == 0
         Success.new(object['message-id'])
       else

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -53,5 +53,30 @@ describe Nexmo::Client do
       response.failure?.must_equal(true)
       response.error.to_s.must_equal('Missing from param (status=2)')
     end
+
+    it 'should return a failure response if nexmo service returns HTTP ERROR: 500' do
+      http_response = stub(:body => '<html>
+      <head>
+      <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
+      <title>Error 500 Server Error</title>
+      </head>
+      <body>
+      <h2>HTTP ERROR: 500</h2>
+      <p>Problem accessing /sms/json. Reason:
+      <pre>    Server Error</pre></p>
+      <hr /><i><small>Powered by Jetty://</small></i>
+      </body>
+      </html>')
+
+      data = 'to=number&text=Hey%21&username=key&password=secret'
+
+      @client.http.expects(:post).with('/sms/json', data, @headers).returns(http_response)
+
+      response = @client.send_message({to: 'number', text: 'Hey!'})
+
+      response.success?.must_equal(false)
+      response.failure?.must_equal(true)
+      response.error.to_s.must_equal('Internal error (status=5)')
+    end
   end
 end


### PR DESCRIPTION
This is a bug fix for issue #4.

When Nexmo service returns html response instead of json response, send_message method fails to parse the response. This fix handles the JSON::ParseError exception and formats 'Internal error' response.
