### PR TITLE
Fix "Unexpected HTTP response (code=200)"

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -20,7 +20,7 @@ module Nexmo
     def send_message(data)
       response = @http.post('/sms/json', encode(data), headers)
 
-      if response.code.to_i == 200 && response['Content-Type'] == 'application/json'
+      if response.code.to_i == 200 && response['Content-Type'].sub(/;.*/, '') == 'application/json'
         object = JSON.parse(response.body)['messages'].first
 
         status = object['status'].to_i

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -28,7 +28,7 @@ module Nexmo
         if status == 0
           Success.new(object['message-id'])
         else
-          Failure.new(Error.new("#{object['error-text']} (status=#{status})"), response)
+          Failure.new(Error.new("#{object['error-text']} (status=#{status})"), response, status)
         end
       else
         Failure.new(Error.new("Unexpected HTTP response (code=#{response.code})"), response)
@@ -52,7 +52,7 @@ module Nexmo
     end
   end
 
-  class Failure < Struct.new(:error, :http)
+  class Failure < Struct.new(:error, :http, :status)
     def success?
       false
     end

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -28,7 +28,7 @@ describe Nexmo::Client do
 
     it 'should make the correct http call and return a success object if the first message status equals 0' do
       http_response = stub(:code => '200', :body => '{"messages":[{"status":0,"message-id":"id"}]}')
-      http_response.expects(:[]).with('Content-Type').returns('application/json')
+      http_response.expects(:[]).with('Content-Type').returns('application/json;charset=utf-8')
 
       data = 'from=ruby&to=number&text=Hey%21&username=key&password=secret'
 


### PR DESCRIPTION
Hi Tim,

Thanks for the library.

With your changes from 5 hours ago, I get "Unexpected HTTP response (code=200)". The culprit turns out to be the `Content-Type` check, which gets confused by `application/json;charset=ISO-8859-1`, which for some reason is how Nexmo responds to me.
