### PR TITLE
Add an optional sleep param

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,7 @@ module Nexmo
     end
 
     def send_message!(params)
-      sleep :sleep
+      sleep params[:sleep]
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,8 +22,8 @@ module Nexmo
       post('/sms/json', params)
     end
 
-    def send_message!(params)
-      response = send_message(params)
+    def send_message!(params, delay)
+      response = send_message(params, delay)
 
       if response.ok? && response.json?
         item = response.object['messages'].first

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,7 @@ module Nexmo
     end
 
     def send_message!(params)
-      sleep 'sleep'
+      sleep :sleep
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -17,7 +17,8 @@ module Nexmo
 
     attr_accessor :key, :secret, :http, :oauth_access_token
 
-    def send_message(params)
+    def send_message(params, delay)
+      sleep(delay)
       post('/sms/json', params)
     end
 

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,7 @@ module Nexmo
     end
 
     def send_message!(params)
-      sleep(1)
+      sleep 1
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,7 @@ module Nexmo
     end
 
     def send_message!(params, delay)
-      sleep(2)
+      sleep(delay)
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,9 @@ module Nexmo
     end
 
     def send_message!(params)
-      sleep params[:sleep]
+      
+      if params.include?(:sleep) then sleep params[:sleep] end
+      
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -17,13 +17,13 @@ module Nexmo
 
     attr_accessor :key, :secret, :http, :oauth_access_token
 
-    def send_message(params, delay)
-      sleep(delay)
+    def send_message(params)
       post('/sms/json', params)
     end
 
     def send_message!(params, delay)
-      response = send_message(params, delay)
+      sleep(2)
+      response = send_message(params)
 
       if response.ok? && response.json?
         item = response.object['messages'].first

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,7 @@ module Nexmo
     end
 
     def send_message!(params)
-      sleep 2
+      sleep 'sleep'
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -22,7 +22,7 @@ module Nexmo
     end
 
     def send_message!(params)
-      sleep 1
+      sleep 2
       response = send_message(params)
 
       if response.ok? && response.json?

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -21,8 +21,8 @@ module Nexmo
       post('/sms/json', params)
     end
 
-    def send_message!(params, delay)
-      sleep(delay)
+    def send_message!(params)
+      sleep(1)
       response = send_message(params)
 
       if response.ok? && response.json?


### PR DESCRIPTION
Nexmo can become a bit testy when dealing with a large number of North American messages. Adding an optional sleep param to bring the send rate above the North American rate limit makes dealing with this much easier
