### PR TITLE
Add send_short_code method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ Sending a Short Code (beta)
 Nexmo is currently rolling out the ability to send messages using a shared short code for preapproved use cases. The current use cases fall into three categories (alerts, two-factor authentication, marketing). As of 14JUN2014, only US short codes are being used.
 [Learn More Here](https://docs.nexmo.com/index.php/US-shared-short-code-api)
 
-`:field1...:fieldN` should be renamed and values aligned with your pre-approved message in the Nexmo Dashboard.
-
-Valid Use Cases (required) = 'alert', '2fa', 'marketing'
-
-Valid Country Codes (optional, defaults to 'us') = 'us'
+* `:field1...:fieldN` should be renamed and values aligned with your pre-approved message in the Nexmo Dashboard.
+* Valid Use Cases (required) = `'alert'`, `'2fa'`, `'marketing'`
+* Valid Country Codes (optional, defaults to `'us'`) = `'us'`
 
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ This method call returns a `Nexmo::Response` object, which wraps the underlying
 Net::HTTP response and adds a few convenience methods. Additional methods are
 also provided for managing your account and messages.
 
+Sending a Short Code (beta)
+---------------------------
+
+Nexmo is currently rolling out the ability to send messages using a shared short code for preapproved use cases. The current use cases fall into three categories (alerts, two-factor authentication, marketing). As of 14JUN2014, only US short codes are being used.
+[Learn More Here](https://docs.nexmo.com/index.php/US-shared-short-code-api)
+
+`:field1...:fieldN` should be renamed and values aligned with your pre-approved message in the Nexmo Dashboard.
+Valid Use Cases (required) = 'alert', '2fa', 'marketing'
+Valid Country Codes (optional, defaults to 'us') = 'us'
+
+
+```ruby
+response = nexmo.send_short_code({:to => '...NUMBER...', :from => '...ASSIGNED SHORT CODE...', :field1 => 'Value 1', :field2 => 'Value 2'}, '...USE CASE...', '...COUNTRY CODE...')
+
+if response.ok?
+	# do something with the response.object
+else
+	# handle the error
+end
+```
+
 
 Authenticating with OAuth (beta)
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Nexmo is currently rolling out the ability to send messages using a shared short
 [Learn More Here](https://docs.nexmo.com/index.php/US-shared-short-code-api)
 
 `:field1...:fieldN` should be renamed and values aligned with your pre-approved message in the Nexmo Dashboard.
+
 Valid Use Cases (required) = 'alert', '2fa', 'marketing'
+
 Valid Country Codes (optional, defaults to 'us') = 'us'
 
 

--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -47,6 +47,10 @@ module Nexmo
       end
     end
 
+    def send_short_code(params, use, country_code = 'us')
+      post("/sc/#{country_code}/#{use}/json", params)
+    end
+
     def get_balance
       get('/account/get-balance')
     end

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -16,6 +16,12 @@ describe 'Nexmo::Client' do
 
     @example_message_hash = {:from => 'ruby', :to => 'number', :text => 'Hey!'}
 
+    @example_short_code_hash = {:from => 'ruby', :to => 'number', :field1 => 'Value 1'}
+
+    @example_short_code_country_code = 'us'
+
+    @example_short_code_use = 'alert'
+
     @client = Nexmo::Client.new('key', 'secret')
   end
 
@@ -62,6 +68,14 @@ describe 'Nexmo::Client' do
       })
 
       proc { @client.send_message!(@example_message_hash) }.must_raise(Nexmo::Error)
+    end
+  end
+
+  describe 'send_short_code method' do
+    it 'posts to the short code json resource as an alert and returns a response object' do
+      stub_request(:post, "#@base_url/sc/us/alert/json").with(@json_object)
+
+      @client.send_short_code(@example_short_code_hash, @example_short_code_use, @example_short_code_country_code).must_be_instance_of(Nexmo::Response)
     end
   end
 


### PR DESCRIPTION
Most of the details are updated in the Readme. Highlights:
- Ability to send messages via Shared Short Code
- Three use cases enabled (`alert`, `2fa`, `marketing`)
- country_code option to allow for future short codes outside the US

Responses are documented as being the same for messages. Short Code message contents are submitted in a pre-approved format (i.e. "Your appointment is tomorrow at ${time}.") and the options (${time}) are passed as `:time => '08:30am'`.
