### PR TITLE
Better errors

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -1,12 +1,9 @@
+require 'nexmo/error'
 require 'net/http'
 require 'json'
 require 'cgi'
 
 module Nexmo
-  class Error < StandardError; end
-
-  class AuthenticationError < Error; end
-
   class Client
     attr_accessor :key, :secret, :http
 
@@ -32,7 +29,7 @@ module Nexmo
       if status == 0
         item['message-id']
       else
-        raise Error, "#{item['error-text']} (status=#{status})"
+        raise Error, :message => item['error-text'], :status => status
       end
     end
 
@@ -135,7 +132,7 @@ module Nexmo
       when Net::HTTPUnauthorized
         raise AuthenticationError
       else
-        raise Error, "Unexpected HTTP response (code=#{http_response.code})"
+        raise Error, :message => "Unexpected HTTP response", :http_status => http_response.code
       end
     end
 

--- a/lib/nexmo/error.rb
+++ b/lib/nexmo/error.rb
@@ -1,0 +1,24 @@
+module Nexmo
+  class Error < StandardError
+    attr_reader :status, :http_status
+
+    # Initialize a new Error.
+    #
+    # status      - The response status code returned by the API.
+    # http_status - The HTTP status code returned by the API.
+    # message     - The error message.
+    #
+    # Returns nothing.
+    def initialize(options = {})
+      if options.kind_of?(Hash)
+        @status = options[:status]
+        @http_status = options[:http_status]
+        super(options[:message])
+      else
+        super(options)
+      end
+    end
+  end
+
+  class AuthenticationError < Error; end
+end

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -43,8 +43,8 @@ describe 'Nexmo::Client' do
 
       stub_request(:post, "#@base_url/sms/json").with(@form_urlencoded_data).to_return(response_body)
 
-      exception = proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::Error)
-
+      exception = proc { @client.send_message(@example_message_hash) }.must_raise Nexmo::Error
+      exception.status.must_equal 2
       exception.message.must_include('Missing from param')
     end
   end
@@ -250,13 +250,14 @@ describe 'Nexmo::Client' do
   it 'raises an exception if the response code is not 2xx' do
     stub_request(:post, "#@base_url/sms/json").with(@form_urlencoded_data).to_return(status: 500)
 
-    proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::Error)
+    exception = proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::Error)
+    exception.http_status.must_equal "500"
   end
 
   it 'raises an authentication error exception if the response code is 401' do
     stub_request(:post, "#@base_url/sms/json").with(@form_urlencoded_data).to_return(status: 401)
 
-    proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::AuthenticationError)
+    exception = proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::AuthenticationError)
   end
 
   it 'provides an option for specifying a different hostname to connect to' do


### PR DESCRIPTION
This PR adds `#status` and `#http_status` accessors to the `Nexmo::Error` class. This should make it easier for API consumers to respond to errors.
