### PR TITLE
prevent raise error when message failed to send

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -24,10 +24,13 @@ module Nexmo
       item = response['messages'].first
 
       status = item['status'].to_i
-
-      raise Error, "#{item['error-text']} (status=#{status})" unless status.zero?
-
-      return item
+      
+      unless status.zero?
+        return {status: status, message: item['error-text']}
+      else
+        return item
+      end
+      
     end
 
     def get_balance

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -37,7 +37,7 @@ describe 'Nexmo::Client' do
 
       stub_request(:post, "#@base_url/sms/json").with(@form_urlencoded_data).to_return(response_body)
 
-      exception = proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::Error)
+      exception = proc { @client.send_message(@example_message_hash) }.to_return(response_body)
 
       exception.message.must_include('Missing from param')
     end


### PR DESCRIPTION
Response status instead raise error, so we can control when error occurred (it can be wrong number, blocked by operation cellular, etc.)
