### PR TITLE
Add method to Number Insight Basic API Beta

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -118,6 +118,10 @@ module Nexmo
       post('https://api.nexmo.com/verify/control/json', params)
     end
 
+    def number_format(params)
+      post('https://api.nexmo.com/number/format/json', params)
+    end
+
     def request_number_insight(params)
       post('/ni/json', params)
     end

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -261,6 +261,16 @@ describe 'Nexmo::Client' do
     end
   end
 
+  describe 'number_format method' do
+    it 'posts to the number insight basic resource and returns the response object' do
+      url = "#@api_base_url/number/format/json"
+
+      stub_request(:post, url).with(@form_urlencoded_data).to_return(@json_response_body)
+
+      @client.number_format(number: '447525856424')
+    end
+  end
+
   describe 'request_number_insight method' do
     it 'posts to the number insight resource and returns the response object' do
       url = "#@base_url/ni/json"


### PR DESCRIPTION
There is nice new Number Insight Basic API :)
https://docs.nexmo.com/api-ref/number-insight/basic

Example response:

```
@client.number_format({number: '48886347301'})
=> {"status"=>0, "status_message"=>"Success", "request_id"=>"8fe17b66-9245-46a4-936d-836a04332fcf", "international_format_number"=>"48886347301", "national_format_number"=>"886 347 301", "country_code"=>"PL", "country_code_iso3"=>"POL", "country_name"=>"Poland", "country_prefix"=>"48"}
```
