### PR TITLE
Ability to override API base url & use different types of hosts

### DIFF
--- a/lib/nexmo.rb
+++ b/lib/nexmo.rb
@@ -17,148 +17,147 @@ module Nexmo
 
     def initialize(options = {})
       @key = options.fetch(:key) { ENV.fetch('NEXMO_API_KEY') }
-
       @secret = options.fetch(:secret) { ENV.fetch('NEXMO_API_SECRET') }
-
-      @host = options.fetch(:host) { 'rest.nexmo.com' }
+      @host = options[:host]
+      @default_hosts = { rest: 'https://rest.nexmo.com', api: 'https://api.nexmo.com' }
     end
 
     def send_message(params)
-      post('/sms/json', params)
+      post(:rest, '/sms/json', params)
     end
 
     def get_balance
-      get('/account/get-balance')
+      get(:rest, '/account/get-balance')
     end
 
     def get_country_pricing(country_code)
-      get('/account/get-pricing/outbound', country: country_code)
+      get(:rest, '/account/get-pricing/outbound', country: country_code)
     end
 
     def get_prefix_pricing(prefix)
-      get('/account/get-prefix-pricing/outbound', prefix: prefix)
+      get(:rest, '/account/get-prefix-pricing/outbound', prefix: prefix)
     end
 
     def get_account_numbers(params)
-      get('/account/numbers', params)
+      get(:rest, '/account/numbers', params)
     end
 
     def get_available_numbers(country_code, params = {})
-      get('/number/search', {country: country_code}.merge(params))
+      get(:rest, '/number/search', { country: country_code }.merge(params))
     end
 
     def buy_number(params)
-      post('/number/buy', params)
+      post(:rest, '/number/buy', params)
     end
 
     def cancel_number(params)
-      post('/number/cancel', params)
+      post(:rest, '/number/cancel', params)
     end
 
     def update_number(params)
-      post('/number/update', params)
+      post(:rest, '/number/update', params)
     end
 
     def get_message(id)
-      get('/search/message', id: id)
+      get(:rest, '/search/message', id: id)
     end
 
     def get_message_rejections(params)
-      get('/search/rejections', params)
+      get(:rest, '/search/rejections', params)
     end
 
     def search_messages(params)
-      get('/search/messages', Hash === params ? params : {ids: Array(params)})
+      get(:rest, '/search/messages', Hash === params ? params : { ids: Array(params) })
     end
 
     def send_ussd_push_message(params)
-      post('/ussd/json', params)
+      post(:rest, '/ussd/json', params)
     end
 
     def send_ussd_prompt_message(params)
-      post('/ussd-prompt/json', params)
+      post(:rest, '/ussd-prompt/json', params)
     end
 
     def send_2fa_message(params)
-      post('/sc/us/2fa/json', params)
+      post(:rest, '/sc/us/2fa/json', params)
     end
 
     def send_event_alert_message(params)
-      post('/sc/us/alert/json', params)
+      post(:rest, '/sc/us/alert/json', params)
     end
 
     def send_marketing_message(params)
-      post('/sc/us/marketing/json', params)
+      post(:rest, '/sc/us/marketing/json', params)
     end
 
     def initiate_call(params)
-      post('/call/json', params)
+      post(:rest, '/call/json', params)
     end
 
     def initiate_tts_call(params)
-      post('https://api.nexmo.com/tts/json', params)
+      post(:api, '/tts/json', params)
     end
 
     def initiate_tts_prompt_call(params)
-      post('https://api.nexmo.com/tts-prompt/json', params)
+      post(:api, '/tts-prompt/json', params)
     end
 
     def send_verification_request(params)
-      post('https://api.nexmo.com/verify/json', params)
+      post(:api, '/verify/json', params)
     end
 
     def check_verification_request(params)
-      post('https://api.nexmo.com/verify/check/json', params)
+      post(:api, '/verify/check/json', params)
     end
 
     def get_verification_request(id)
-      get('https://api.nexmo.com/verify/search/json', request_id: id)
+      get(:api, '/verify/search/json', request_id: id)
     end
 
     def control_verification_request(params)
-      post('https://api.nexmo.com/verify/control/json', params)
+      post(:api, '/verify/control/json', params)
     end
 
     def get_basic_number_insight(params)
-      get('https://api.nexmo.com/number/format/json', params)
+      get(:api, '/number/format/json', params)
     end
 
     def get_number_insight(params)
-      get('https://api.nexmo.com/number/lookup/json', params)
+      get(:api, '/number/lookup/json', params)
     end
 
     def request_number_insight(params)
-      post('/ni/json', params)
+      post(:rest, '/ni/json', params)
     end
 
     private
 
     USER_AGENT = "ruby-nexmo/#{VERSION}/#{RUBY_VERSION}"
 
-    def get(path, params = {})
-      uri = URI.join("https://#{@host}", path)
+    def get(default_host_type, path, params = {})
+      uri = build_uri(default_host_type, path)
       uri.query = query_string(params.merge(api_key: @key, api_secret: @secret))
 
-      get_request = Net::HTTP::Get.new(uri.request_uri)
-      get_request['User-Agent'] = USER_AGENT
-
-      http = Net::HTTP.new(uri.host, Net::HTTP.https_default_port)
-      http.use_ssl = true
-
-      parse http.request(get_request), uri.host
+      request = Net::HTTP::Get.new(uri.request_uri)
+      request['User-Agent'] = USER_AGENT
+      make_request(uri, request)
     end
 
-    def post(path, params)
-      uri = URI.join("https://#{@host}", path)
+    def post(default_host_type, path, params)
+      uri = build_uri(default_host_type, path)
 
-      post_request = Net::HTTP::Post.new(uri.request_uri)
-      post_request.form_data = params.merge(api_key: @key, api_secret: @secret)
-      post_request['User-Agent'] = USER_AGENT
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request.form_data = params.merge(api_key: @key, api_secret: @secret)
+      request['User-Agent'] = USER_AGENT
+      make_request(uri, request)
+    end
 
-      http = Net::HTTP.new(uri.host, Net::HTTP.https_default_port)
-      http.use_ssl = true
+    def make_request(uri, request)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.is_a?(URI::HTTPS)
 
-      parse http.request(post_request), uri.host
+      response = http.request(request)
+      parse(response, uri.host)
     end
 
     def parse(http_response, host)
@@ -178,6 +177,12 @@ module Nexmo
       else
         raise Error, "#{http_response.code} response from #{host}"
       end
+    end
+
+    def build_uri(default_host_type, path)
+      host = @host || @default_hosts[default_host_type]
+      host = 'https://' + host unless host.start_with?('http')
+      URI(host + path)
     end
 
     def query_string(params)

--- a/spec/nexmo_spec.rb
+++ b/spec/nexmo_spec.rb
@@ -317,15 +317,39 @@ describe 'Nexmo::Client' do
     proc { @client.send_message(@example_message_hash) }.must_raise(Nexmo::ServerError)
   end
 
-  it 'provides an option for specifying a different hostname to connect to' do
+  it 'provides an option for specifying a different hostname without a protocol' do
     url = "https://rest-sandbox.nexmo.com/account/get-balance?api_key=key&api_secret=secret"
-
     request = stub_request(:get, url).to_return(@json_response_body)
 
     @client = Nexmo::Client.new(key: 'key', secret: 'secret', host: 'rest-sandbox.nexmo.com')
-
     @client.get_balance
+    assert_requested(request)
+  end
 
+  it 'provides an option for specifying a different hostname with HTTP' do
+    url = "http://foo.com/account/get-balance?api_key=key&api_secret=secret"
+    request = stub_request(:get, url).to_return(@json_response_body)
+
+    @client = Nexmo::Client.new(key: 'key', secret: 'secret', host: 'http://foo.com')
+    @client.get_balance
+    assert_requested(request)
+  end
+
+  it 'provides an option for specifying a different hostname with HTTPS' do
+    url = "https://foo.com/account/get-balance?api_key=key&api_secret=secret"
+    request = stub_request(:get, url).to_return(@json_response_body)
+
+    @client = Nexmo::Client.new(key: 'key', secret: 'secret', host: 'https://foo.com')
+    @client.get_balance
+    assert_requested(request)
+  end
+
+  it 'provides an option for specifying a different hostname including a path' do
+    url = "https://foo.com/nexmo/account/get-balance?api_key=key&api_secret=secret"
+    request = stub_request(:get, url).to_return(@json_response_body)
+
+    @client = Nexmo::Client.new(key: 'key', secret: 'secret', host: 'https://foo.com/nexmo')
+    @client.get_balance
     assert_requested(request)
   end
 end


### PR DESCRIPTION
This gives ability to 
- Override the base URL of https://api.nexmo.com requests.
- Provide a host with HTTP or HTTPS.
- Use HTTPS by default for hosts without a specified protocol. (to ensure backward compatibility with current behavior)
