### PR TITLE
Add proxy support

### DIFF
--- a/lib/nexmo/client.rb
+++ b/lib/nexmo/client.rb
@@ -9,6 +9,8 @@ module Nexmo
     attr_writer :private_key
     attr_writer :token
     attr_accessor :user_agent
+    attr_accessor :proxy_addr
+    attr_accessor :proxy_port
 
     def initialize(options = {})
       @api_key = options[:api_key] || ENV['NEXMO_API_KEY']
@@ -26,6 +28,10 @@ module Nexmo
       @user_agent = UserAgent.string(options[:app_name], options[:app_version])
 
       self.logger = options[:logger] || (defined?(Rails.logger) && Rails.logger)
+
+      @proxy_addr = options[:proxy_addr]
+
+      @proxy_port = options[:proxy_port]
     end
 
     def logger

--- a/lib/nexmo/namespace.rb
+++ b/lib/nexmo/namespace.rb
@@ -11,7 +11,7 @@ module Nexmo
 
       @host = self.class.host
 
-      @http = Net::HTTP.new(@host, Net::HTTP.https_default_port)
+      @http = Net::HTTP.new(@host, Net::HTTP.https_default_port, @client.proxy_addr, @client.proxy_port)
       @http.use_ssl = true
     end
 

--- a/lib/nexmo/namespace.rb
+++ b/lib/nexmo/namespace.rb
@@ -15,6 +15,8 @@ module Nexmo
       @http.use_ssl = true
     end
 
+    attr_reader :http
+
     def self.host
       @host ||= 'api.nexmo.com'
     end


### PR DESCRIPTION
Adds proxy_addr and proxy_port options. Example usage with [Charles](https://www.charlesproxy.com):

```ruby
require 'nexmo'

client = Nexmo::Client.new({
  api_key: 'API_KEY',
  api_secret: 'API_SECRET',
  proxy_addr: 'localhost',
  proxy_port: 8888,
  logger: Logger.new(STDOUT)
})

client.account.http.ca_file = 'charles-ssl-proxying-certificate.pem'

client.account.balance
```

Webmock unfortunately doesn't support testing the net/http proxy functionality.