### PR TITLE
Update and rename "Send an SMS" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then construct a client object with your key and secret:
 client = Nexmo::Client.new(api_key: 'YOUR-API-KEY', api_secret: 'YOUR-API-SECRET')
 ```
 
-You can now use the client object to [send a text message](#send-a-text-message),
+You can now use the client object to [send an SMS](#send-an-sms),
 [start a verification](#start-a-verification), or [create an application](#create-an-application).
 
 For production you can specify the `NEXMO_API_KEY` and `NEXMO_API_SECRET`


### PR DESCRIPTION
Previous link was linking to a broken header. Updated the link to redirect to the correct header. 