### PR TITLE
Introduce all Nexmo signing hashing options to Signature

### DIFF
--- a/lib/nexmo/signature.rb
+++ b/lib/nexmo/signature.rb
@@ -20,7 +20,7 @@ module Nexmo
     #
     # @see https://developer.nexmo.com/concepts/guides/signing-messages
     #
-    def check(signature_method, params)
+    def check(signature_method = 'md5hash', params)
       params = params.dup
 
       signature = params.delete('sig')
@@ -30,7 +30,7 @@ module Nexmo
 
     private
 
-    def digest(signature_method = 'md5hash', params)
+    def digest(signature_method, params)
       case signature_method
       when 'md5hash', 'md5'
         hash = OpenSSL::Digest::MD5.new

--- a/lib/nexmo/signature.rb
+++ b/lib/nexmo/signature.rb
@@ -30,7 +30,7 @@ module Nexmo
 
     private
 
-    def digest(signature_method, params)
+    def digest(signature_method = 'md5hash', params)
       case signature_method
       when 'md5hash', 'md5'
         hash = OpenSSL::Digest::MD5.new

--- a/lib/nexmo/signature.rb
+++ b/lib/nexmo/signature.rb
@@ -1,4 +1,3 @@
-require 'digest'
 require 'jwt'
 module Nexmo
   class Signature
@@ -33,14 +32,14 @@ module Nexmo
 
     def digest(signature_method, params)
       case signature_method
-      when 'md5'
-        hash = Digest::MD5.new
+      when 'md5hash', 'md5'
+        hash = OpenSSL::Digest::MD5.new
       when 'sha1'
-        hash = Digest::SHA1.new
+        hash = OpenSSL::Digest::SHA1.new
       when 'sha256'
-        hash = Digest::SHA256.new
+        hash = OpenSSL::Digest::SHA256.new
       when 'sha512'
-        hash = Digest::SHA512.new
+        hash = OpenSSL::Digest::SHA512.new
       else
         raise "Unknown signature algorithm: #{signature_method}. Expected: md5hash, md5, sha1, sha256, or sha512."
       end
@@ -51,7 +50,11 @@ module Nexmo
 
       hash.update(@secret)
 
-      hash.hexdigest
+      if signature_method == 'md5'
+        hash = OpenSSL::HMAC.hexdigest(hash, @secret, params.to_s)
+      else
+        hash.hexdigest
+      end
     end
   end
 end

--- a/lib/nexmo/signature.rb
+++ b/lib/nexmo/signature.rb
@@ -41,9 +41,9 @@ module Nexmo
       end
 
       if ['md5', 'sha1', 'sha256', 'sha512'].include? signature_method
-        digest = OpenSSL::HMAC.hexdigest(signature_method, @secret, digest_string).upcase
+        OpenSSL::HMAC.hexdigest(signature_method, @secret, digest_string).upcase
       elsif signature_method == 'md5hash'
-        digest = Digest::MD5.hexdigest("#{digest_string}#{@secret}")
+        Digest::MD5.hexdigest("#{digest_string}#{@secret}")
       else
         raise "Unknown signature algorithm: #{signature_method}. Expected: md5hash, md5, sha1, sha256, or sha512."
       end

--- a/lib/nexmo/signature.rb
+++ b/lib/nexmo/signature.rb
@@ -1,5 +1,5 @@
 require 'openssl'
-require 'digest'
+require 'digest/md5'
 require 'jwt'
 
 module Nexmo

--- a/lib/nexmo/signature.rb
+++ b/lib/nexmo/signature.rb
@@ -36,7 +36,7 @@ module Nexmo
     def digest(params, signature_method)
       digest_string = ''
       params.sort.each do |k, v|
-        v.gsub(/[&_]/, '')
+        v = v.tr('&=', '')
         digest_string << "&#{k}=#{v}"
       end
 

--- a/test/nexmo/signature_test.rb
+++ b/test/nexmo/signature_test.rb
@@ -36,45 +36,45 @@ class NexmoSignatureTest < Minitest::Test
   def test_check_instance_method_with_md5hash
     signature = Nexmo::Signature.new(secret)
 
-    assert_equal signature.check('md5hash', params_with_valid_signature_md5hash), true
-    assert_equal signature.check('md5hash', params_with_invalid_signature), false
+    assert_equal signature.check(params_with_valid_signature_md5hash, signature_method: 'md5hash'), true
+    assert_equal signature.check(params_with_invalid_signature, signature_method: 'md5hash'), false
   end
 
   def test_check_instance_method_with_md5hmac
     signature = Nexmo::Signature.new(secret)
 
-    assert_equal signature.check('md5', params_with_valid_signature_md5), true
-    assert_equal signature.check('md5', params_with_invalid_signature), false
+    assert_equal signature.check(params_with_valid_signature_md5, signature_method: 'md5'), true
+    assert_equal signature.check(params_with_invalid_signature, signature_method: 'md5'), false
   end
 
   def test_check_instance_method_with_sha1
     signature = Nexmo::Signature.new(secret)
 
-    assert_equal signature.check('sha1', params_with_valid_signature_sha1), true
-    assert_equal signature.check('sha1', params_with_invalid_signature), false
+    assert_equal signature.check(params_with_valid_signature_sha1, signature_method: 'sha1'), true
+    assert_equal signature.check(params_with_invalid_signature, signature_method: 'sha1'), false
   end
 
   def test_check_instance_method_with_sha256
     signature = Nexmo::Signature.new(secret)
 
-    assert_equal signature.check('sha256', params_with_valid_signature_sha256), true
-    assert_equal signature.check('sha256', params_with_invalid_signature), false
+    assert_equal signature.check(params_with_valid_signature_sha256, signature_method: 'sha256'), true
+    assert_equal signature.check(params_with_invalid_signature, signature_method: 'sha256'), false
   end
 
   def test_check_instance_method_with_sha512
     signature = Nexmo::Signature.new(secret)
 
-    assert_equal signature.check('sha512', params_with_valid_signature_sha512), true
-    assert_equal signature.check('sha512', params_with_invalid_signature), false
+    assert_equal signature.check(params_with_valid_signature_sha512, signature_method: 'sha512'), true
+    assert_equal signature.check(params_with_invalid_signature, signature_method: 'sha512'), false
   end
 
   def test_check_instance_method_with_unknown_method
     signature = Nexmo::Signature.new(secret)
 
     exception = assert_raises RuntimeError do
-      signature.check('xxxx', params_with_valid_signature_md5)
+      signature.check(params_with_valid_signature_md5, signature_method: 'xxxx')
     end
 
-    assert_equal('Unknown signature algorithm: xxxx. Expected: md5hash, md5, sha1, sha256, or sha512.', exception.message)
+    assert_equal 'Unknown signature algorithm: xxxx. Expected: md5hash, md5, sha1, sha256, or sha512.', exception.message
   end
 end

--- a/test/nexmo/signature_test.rb
+++ b/test/nexmo/signature_test.rb
@@ -9,18 +9,61 @@ class NexmoSignatureTest < Minitest::Test
     {'a' => '1', 'b' => '2', 'timestamp' => '1461605396'}
   end
 
-  def params_with_valid_signature
+  def params_with_valid_signature_md5
     params.merge('sig' => '6af838ef94998832dbfc29020b564830')
+  end
+
+  def params_with_valid_signature_sha1
+    params.merge('sig' => '879d0c829f44d32d29793187a8c9ec882a97dc0b')
+  end
+
+  def params_with_valid_signature_sha256
+    params.merge('sig' => '21c048bfc4fdcd3532ceb8dc110779d0fd2b754ea38b9eeb4ac17800a09d9ccd')
+  end
+
+  def params_with_valid_signature_sha512
+    params.merge('sig' => '022fb2c734fcffc959fe66cdd8b625b9783ae7c38e1c7cc90bbe0bdde25688bdfbf2dc98abbfac2d3ef73ce3cc305d30bfaba370c831059c6fc336c9557f0d75')
   end
 
   def params_with_invalid_signature
     params.merge('sig' => 'xxx')
   end
 
-  def test_check_instance_method
+  def test_check_instance_method_with_md5
     signature = Nexmo::Signature.new(secret)
 
-    assert_equal signature.check(params_with_valid_signature), true
-    assert_equal signature.check(params_with_invalid_signature), false
+    assert_equal signature.check('md5', params_with_valid_signature_md5), true
+    assert_equal signature.check('md5', params_with_invalid_signature), false
+  end
+
+  def test_check_instance_method_with_sha1
+    signature = Nexmo::Signature.new(secret)
+
+    assert_equal signature.check('sha1', params_with_valid_signature_sha1), true
+    assert_equal signature.check('sha1', params_with_invalid_signature), false
+  end
+
+  def test_check_instance_method_with_sha256
+    signature = Nexmo::Signature.new(secret)
+
+    assert_equal signature.check('sha256', params_with_valid_signature_sha256), true
+    assert_equal signature.check('sha256', params_with_invalid_signature), false
+  end
+
+  def test_check_instance_method_with_sha512
+    signature = Nexmo::Signature.new(secret)
+
+    assert_equal signature.check('sha512', params_with_valid_signature_sha512), true
+    assert_equal signature.check('sha512', params_with_invalid_signature), false
+  end
+
+  def test_check_instance_method_with_unknown_method
+    signature = Nexmo::Signature.new(secret)
+
+    exception = assert_raises RuntimeError do
+      signature.check('xxxx', params_with_valid_signature_md5)
+    end
+
+    assert_equal('Unknown signature algorithm: xxxx. Expected: md5hash, md5, sha1, sha256, or sha512.', exception.message)
   end
 end

--- a/test/nexmo/signature_test.rb
+++ b/test/nexmo/signature_test.rb
@@ -2,31 +2,39 @@ require_relative './test'
 
 class NexmoSignatureTest < Minitest::Test
   def secret
-    'secret'
+    'my_secret_key_for_testing'
   end
 
   def params
-    {'a' => '1', 'b' => '2', 'timestamp' => '1461605396'}
+    {
+      'message-timestamp' => '2013-11-21 15:27:30',
+      'messageId' => '020000001B0FE827',
+      'msisdn' => '14843472194',
+      'text' => 'Test again',
+      'timestamp' => '1385047698',
+      'to' => '13239877404',
+      'type' => 'text'
+    }
   end
 
   def params_with_valid_signature_md5hash
-    params.merge('sig' => '6af838ef94998832dbfc29020b564830')
+    params.merge('sig' => 'd2e7b1dc968737c5998ad624e02f90b7')
   end
 
   def params_with_valid_signature_md5
-    params.merge('sig' => 'c5725da0ac958d4e03a90f3eeefa1475')
+    params.merge('sig' => 'DDEBD46008C2D4E93CCE578A332A52D5')
   end
 
   def params_with_valid_signature_sha1
-    params.merge('sig' => '879d0c829f44d32d29793187a8c9ec882a97dc0b')
+    params.merge('sig' => '27D0D05C2876C7CB1720DBCDBA4D492E1E55C09A')
   end
 
   def params_with_valid_signature_sha256
-    params.merge('sig' => '21c048bfc4fdcd3532ceb8dc110779d0fd2b754ea38b9eeb4ac17800a09d9ccd')
+    params.merge('sig' => 'DDB8397C2B90AAC7F3882D306475C9A5058C92322EEF43C92B298B6E0FC0D330')
   end
 
   def params_with_valid_signature_sha512
-    params.merge('sig' => '022fb2c734fcffc959fe66cdd8b625b9783ae7c38e1c7cc90bbe0bdde25688bdfbf2dc98abbfac2d3ef73ce3cc305d30bfaba370c831059c6fc336c9557f0d75')
+    params.merge('sig' => 'E0D3C650F8C9D1A5C174D10DDDBFB003E561F59B265616208B0487C5D819481CD3C311D59CF6165ECD1139622D5BA3A256C0D763AC4A9AD9144B5A426B94FE82')
   end
 
   def params_with_invalid_signature

--- a/test/nexmo/signature_test.rb
+++ b/test/nexmo/signature_test.rb
@@ -9,8 +9,12 @@ class NexmoSignatureTest < Minitest::Test
     {'a' => '1', 'b' => '2', 'timestamp' => '1461605396'}
   end
 
-  def params_with_valid_signature_md5
+  def params_with_valid_signature_md5hash
     params.merge('sig' => '6af838ef94998832dbfc29020b564830')
+  end
+
+  def params_with_valid_signature_md5
+    params.merge('sig' => 'c5725da0ac958d4e03a90f3eeefa1475')
   end
 
   def params_with_valid_signature_sha1
@@ -29,7 +33,14 @@ class NexmoSignatureTest < Minitest::Test
     params.merge('sig' => 'xxx')
   end
 
-  def test_check_instance_method_with_md5
+  def test_check_instance_method_with_md5hash
+    signature = Nexmo::Signature.new(secret)
+
+    assert_equal signature.check('md5hash', params_with_valid_signature_md5hash), true
+    assert_equal signature.check('md5hash', params_with_invalid_signature), false
+  end
+
+  def test_check_instance_method_with_md5hmac
     signature = Nexmo::Signature.new(secret)
 
     assert_equal signature.check('md5', params_with_valid_signature_md5), true


### PR DESCRIPTION
This PR brings the Ruby SDK into conformity with the API requirement of allowing for multiple hashing options (https://developer.nexmo.com/concepts/guides/signing-messages), specifically: `md5`, `md5hash`, `sha1`, `sha256` and `sha512`. It does this by refactoring to use the built in `OpenSSL` functionality instead of the `Digest` gem, which does not have MD5 HMAC capabilities. New tests are introduced to verify each signature hashing option. The final message for an invalid option in the `case` statement is in line with the messaging offered in parallel SDKs (i.e. https://github.com/Nexmo/nexmo-php/blob/master/src/Client/Signature.php#L59-L72), as is the code structure. 