### PR TITLE
add coveralls repo token to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
       run: bundle install --without development
     - name: Run tests
       run: bundle exec rake test_with_coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
As @mheap discovered when adding Coveralls to the Python SDK in Actions and in the Vonage GitHub organization, we need to expose the Coveralls Repo Token to the GitHub Actions workflow. This PR adds the token as an environment variable to the workflow.