### PR TITLE
update Nexmo JWT gem dependency

### DIFF
--- a/vonage.gemspec
+++ b/vonage.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'This is the Ruby Server SDK for Vonage APIs. To use it you\'ll need a Vonage account. Sign up for free at https://www.vonage.com'
   s.files = Dir.glob('lib/**/*.rb') + %w(LICENSE.txt README.md vonage.gemspec)
   s.required_ruby_version = '>= 2.5.0'
-  s.add_dependency('nexmo-jwt', '~> 0.1.1')
+  s.add_dependency('nexmo-jwt', '~> 0.1.2')
   s.add_dependency('zeitwerk', '~> 2', '>= 2.2')
   s.add_dependency('sorbet-runtime', '~> 0.5')
   s.require_path = 'lib'


### PR DESCRIPTION
Update to `nexmo-jwt` v0.1.2 that fixes the ACL path formation