### PR TITLE
Increase file level typedness at least `typed: true`

### DIFF
--- a/lib/vonage/abstract_authentication.rb
+++ b/lib/vonage/abstract_authentication.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 module Vonage
   class AbstractAuthentication

--- a/lib/vonage/applications/list_response.rb
+++ b/lib/vonage/applications/list_response.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 class Vonage::Applications::ListResponse < Vonage::Response
   include Enumerable

--- a/lib/vonage/basic.rb
+++ b/lib/vonage/basic.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 module Vonage
   class Basic < AbstractAuthentication

--- a/lib/vonage/bearer_token.rb
+++ b/lib/vonage/bearer_token.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 # frozen_string_literal: true
 
 module Vonage

--- a/lib/vonage/form_data.rb
+++ b/lib/vonage/form_data.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 module Vonage
   module FormData

--- a/lib/vonage/jwt.rb
+++ b/lib/vonage/jwt.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 require 'securerandom'
 require 'openssl'

--- a/lib/vonage/namespace.rb
+++ b/lib/vonage/namespace.rb
@@ -61,7 +61,7 @@ module Vonage
       authentication = self.class.authentication.new(@config)
       authentication.update(params)
 
-      unless type::REQUEST_HAS_BODY || params.empty?
+      unless type.const_get(:REQUEST_HAS_BODY) || params.empty?
         uri.query = Params.encode(params)
       end
 
@@ -77,7 +77,7 @@ module Vonage
 
       authentication.update(message)
 
-      self.class.request_body.update(message, params) if type::REQUEST_HAS_BODY
+      self.class.request_body.update(message, params) if type.const_get(:REQUEST_HAS_BODY)
 
       logger.log_request_info(message)
 

--- a/lib/vonage/namespace.rb
+++ b/lib/vonage/namespace.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 # frozen_string_literal: true
 require 'net/http'
 require 'json'

--- a/lib/vonage/numbers/list_response.rb
+++ b/lib/vonage/numbers/list_response.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 class Vonage::Numbers::ListResponse < Vonage::Response
   include Enumerable

--- a/lib/vonage/numbers/response.rb
+++ b/lib/vonage/numbers/response.rb
@@ -3,6 +3,6 @@
 
 class Vonage::Numbers::Response < Vonage::Response
   def success?
-    error_code == '200'
+    T.unsafe(self).error_code == '200'
   end
 end

--- a/lib/vonage/numbers/response.rb
+++ b/lib/vonage/numbers/response.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 class Vonage::Numbers::Response < Vonage::Response

--- a/lib/vonage/params.rb
+++ b/lib/vonage/params.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 # frozen_string_literal: true
 require 'cgi'
 

--- a/lib/vonage/secrets/list_response.rb
+++ b/lib/vonage/secrets/list_response.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 class Vonage::Secrets::ListResponse < Vonage::Response
   include Enumerable

--- a/lib/vonage/voice/list_response.rb
+++ b/lib/vonage/voice/list_response.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 
 class Vonage::Voice::ListResponse < Vonage::Response
   include Enumerable


### PR DESCRIPTION
## Issue

Part of https://github.com/Vonage/vonage-ruby-sdk/issues/178

## Changes

As described in https://sorbet.org/docs/metrics, Sorbet recommends us to increase file-level typedness to measure adoption of Sorbet.

So I increased file-level typedness of files that have had low level typedness (`typed: ignore` or `typed: false`). With this change, all files get to have at least `typed: true`.

