### PR TITLE
Ignore test directory during type checking

### DIFF
--- a/sorbet/config
+++ b/sorbet/config
@@ -1,2 +1,3 @@
+--ignore=/test
 --dir
 .


### PR DESCRIPTION
Ignore the spec folder while running Sorbet type checking