### PR TITLE
add ruby 3.0 to ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         ruby: [2.5, 2.6, 2.7, 3.0]
+        exclude:
+          - os: windows-latest
+            ruby: 3.0
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/vonage.gemspec
+++ b/vonage.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nexmo-jwt', '~> 0.1.2')
   s.add_dependency('zeitwerk', '~> 2', '>= 2.2')
   s.add_dependency('sorbet-runtime', '~> 0.5')
+  s.add_runtime_dependency('rexml')
   s.require_path = 'lib'
   s.metadata = {
     'homepage' => 'https://github.com/Vonage/vonage-ruby-sdk',


### PR DESCRIPTION
* Add Ruby 3 to the CI
* Add the `rexml` gem explicitly to the gemspec, as Ruby 3 removes it from the standard library
* Exclude Ruby 3 from the Windows build in the CI as it's not included yet