### PR TITLE
add initial work on validator classes

### DIFF
--- a/lib/vonage/voice/validators/create_call.rb
+++ b/lib/vonage/voice/validators/create_call.rb
@@ -1,0 +1,129 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module Vonage
+  class Voice::Validators::CreateCall < Namespace
+    attr_accessor :to, :from, :event_url, :event_method, :machine_detection, :length_timer, :ringing_timer, :ncco, :answer_url
+
+    def initialize(params = {})
+      @to = params.fetch(:to)
+      @from = params.fetch(:from)
+      @event_url = params.fetch(:event_url, nil)
+      @event_method = params.fetch(:event_method, nil)
+      @machine_detection = params.fetch(:machine_detection, nil)
+      @length_timer = params.fetch(:length_timer, nil)
+      @ringing_timer = params.fetch(:ringing_timer, nil)
+      @ncco = params.fetch(:ncco, nil)
+      @answer_url = params.fetch(:answer_url, nil)
+
+      after_initialize!(self)
+    end
+
+    def after_initialize!(builder)
+      validate_no_params_conflict(builder)
+      validate_required_params_data(builder)
+      validate_optional_params_data(builder)
+    end
+
+    def validate_no_params_conflict(builder)
+      if builder.ncco && builder.answer_url
+        raise ClientError.new("Expected either 'ncco' param or 'answer_url' param, not both")
+      end
+    end
+
+    def validate_required_params_data(builder)
+      validate_to_param(builder.to)
+      validate_from_param(builder.from)
+      if !builder.ncco && !builder.answer_url
+        raise ClientError.new("Expected either 'answer_url' or 'ncco' parameter to be provided")
+      end
+
+      if builder.ncco && !builder.answer_url
+        validate_ncco_param(builder.ncco)
+      end
+
+      if !builder.ncco && builder.answer_url
+        validate_answer_url_param(builder.answer_url)
+      end
+    end
+
+    def validate_optional_params_data(builder)
+      if builder.event_url
+        validate_event_url_param(builder.event_url)
+      end
+
+      if builder.event_method
+        validate_event_method_param(builder.event_method)
+      end
+
+      if builder.ringing_timer
+        validate_ringing_timer_param(builder.ringing_timer)
+      end
+
+      if builder.length_timer
+        validate_length_timer_param(builder.length_timer)
+      end
+
+      if builder.machine_detection
+        validate_machine_detection_param(builder.machine_detection)
+      end
+    end
+
+    def validate_machine_detection_param(machine_detection_param)
+      raise ClientError.new("Expected value of 'machine_detection' parameter to be a String") if !machine_detection_param.is_a?(String)
+      raise ClientError.new("Expected value of 'machine_detection' parameter to be either 'continue' or 'hangup'") unless machine_detection_param == 'continue' || machine_detection_param == 'hangup'
+    end
+
+    def validate_to_param(to_param)
+      raise ClientError.new("Expected 'to' parameter to be an Array") if !to_param.is_a?(Array)
+      raise ClientError.new("Expected value of 'to' parameter to be a Hash") if !to_param[0].is_a?(Hash)
+      raise ClientError.new("Expected 'to' parameter to be an Array of only one value") if to_param.count > 1
+
+      raise ClientError.new("Expected a String for the value of 'type'") if !to_param[0][:type].is_a?(String)
+      raise ClientError.new("Expected a String for the value of 'number'") if !to_param[0][:number].is_a?(String)
+      raise ClientError.new("Expected 'number' value to be between 7 and 15 digits") if to_param[0][:number].length < 7 || to_param[0][:number].length > 15
+      raise ClientError.new("Expected 'dtmfAnswer' value to be a String") if to_param[0][:dtmfAnswer] && !to_param[0][:dtmfAnswer].is_a?(String)
+    end
+
+    def validate_from_param(from_param)
+      raise ClientError.new("Expected 'from' parameter to be a Hash") if !from_param.is_a?(Hash)
+      raise ClientError.new("Expected 'from' parameter to only have two keys: 'type' and 'number'") if from_param.keys.count > 2
+
+      raise ClientError.new("Expected a String for the value of 'type'") if !from_param[:type].is_a?(String)
+      raise ClientError.new("Expected a String for the value of 'number'") if !from_param[:number].is_a?(String)
+      raise ClientError.new("Expected 'number' value to be between 7 and 15 digits") if from_param[:number].length < 7 || from_param[:number].length > 15
+    end
+
+    def validate_ncco_param(ncco_param)
+      raise ClientError.new("Expected 'ncco' parameter to be an Array") if !ncco_param.is_a?(Array)
+      raise ClientError.new("Expected value of 'ncco' parameter to be a Hash") if !ncco_param[0].is_a?(Hash)
+    end
+
+    def validate_answer_url_param(answer_url_param)
+      raise ClientError.new("Expected 'answer_url' parameter to be an Array") if !answer_url_param.is_a?(Array)
+      raise ClientError.new("Expected value of 'answer_url' parameter to be a String") if !answer_url_param[0].is_a?(String)
+      raise ClientError.new("Expected only one String value of 'answer_url' parameter") if answer_url_param.count > 1
+    end
+
+    def validate_event_url_param(event_url_param)
+      raise ClientError.new("Expected 'event_url' parameter to be an Array") if !event_url_param.is_a?(Array)
+      raise ClientError.new("Expected value of 'event_url' parameter to be a String") if !event_url_param[0].is_a?(String)
+      raise ClientError.new("Expected only one String value of 'event_url' parameter") if event_url_param.count > 1
+    end
+
+    def validate_event_method_param(event_method_param)
+      raise ClientError.new("Expected value of 'event_method' parameter to be a String") if !event_method_param.is_a?(String)
+      raise ClientError.new("Expected value of 'event_method' parameter to be either 'GET' or 'POST'") unless event_method_param == 'GET' || event_method_param == 'POST'
+    end
+
+    def validate_ringing_timer_param(ringing_timer_param)
+      raise ClientError.new("Expected 'ringing_timer' parameter to be an Integer") if !ringing_timer_param.is_a?(Integer)
+      raise ClientError.new("Expected 'ringing_timer' parameter to be between 1 and 120") if ringing_timer_param < 1 || ringing_timer_param > 120
+    end
+
+    def validate_length_timer_param(length_timer_param)
+      raise ClientError.new("Expected 'length_timer' parameter to be an Integer") if !length_timer_param.is_a?(Integer)
+      raise ClientError.new("Expected 'length_timer' parameter to be between 1 and 7200") if length_timer_param < 1 || length_timer_param > 7200
+    end
+  end
+end

--- a/lib/vonage/voice/validators/list_calls.rb
+++ b/lib/vonage/voice/validators/list_calls.rb
@@ -1,0 +1,105 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module Vonage
+  class Voice::Validators::ListCalls < Namespace
+    attr_accessor :status, :date_start, :date_end, :page_size, :record_index, :order, :conversation_uuid
+
+    def initialize(params = {})
+      @status = params.fetch(:status, nil)
+      @date_start = params.fetch(:date_start, nil)
+      @date_end = params.fetch(:date_end, nil)
+      @page_size = params.fetch(:page_size, nil)
+      @record_index = params.fetch(:record_index, nil)
+      @order = params.fetch(:order, nil)
+      @conversation_uuid = params.fetch(:conversation_uuid, nil)
+
+      after_initialize!(self)
+    end
+
+    def after_initialize!(builder)
+      validate_params(builder)
+    end
+
+    def validate_params(builder)
+      if builder.status
+        validate_status_param(builder.status)
+      end
+
+      if builder.date_start
+        validate_date_start_param(builder.date_start)
+      end
+
+      if builder.date_end
+        validate_date_end_param(builder.date_end)
+      end
+
+      if builder.page_size
+        validate_page_size_param(builder.page_size)
+      end
+
+      if builder.record_index
+        validate_record_index_param(builder.record_index)
+      end
+
+      if builder.order
+        validate_order_param(builder.order)
+      end
+
+      if builder.conversation_uuid
+        validate_conversation_uuid_param(builder.conversation_uuid)
+      end
+    end
+
+    def validate_status_param(status)
+      valid_status_states = [
+        'started', 'ringing', 'answered', 'machine', 'completed',
+        'busy', 'cancelled', 'failed', 'rejected', 'timeout',
+        'unanswered'
+      ]
+
+      raise ClientError.new("Expect 'status' parameter to be a String") unless status.is_a?(String)
+      raise ClientError.new("Expect 'status' parameter to be one of: " \
+        "#{valid_status_states.map{|state| "\"#{state}\""}.join(',')}"
+      ) unless valid_status_states.include?(status)
+    end
+
+    def validate_date_start_param(date_start)
+      raise ClientError.new("Expect 'date_start' parameter to be a String") unless date_start.is_a?(String)
+
+      begin
+        DateTime.iso8601(date_start)
+      rescue
+        raise ClientError.new("Expect 'date_start' parameter to be in ISO8601 format")
+      end
+    end
+
+    def validate_date_end_param(date_end)
+      raise ClientError.new("Expect 'date_end' parameter to be a String") unless date_end.is_a?(String)
+
+      begin
+        DateTime.iso8601(date_end)
+      rescue
+        raise ClientError.new("Expect 'date_end' parameter to be in ISO8601 format")
+      end
+    end
+
+    def validate_page_size_param(page_size)
+      raise ClientError.new("Expect 'page_size' parameter to be an Integer") unless page_size.is_a?(Integer)
+    end
+
+    def validate_record_index_param(record_index)
+      raise ClientError.new("Expect 'record_index' parameter to be an Integer") unless record_index.is_a?(Integer)
+    end
+
+    def validate_order_param(order_param)
+      raise ClientError.new("Expect 'order' parameter to be a String") unless order_param.is_a?(String)
+    
+      raise ClientError.new("Expect 'order' parameter value to be either 'asc' or 'desc'") unless order_param == 'asc' || order_param == 'desc'
+    end
+
+    def validate_conversation_uuid_param(conversation_uuid)
+      raise ClientError.new("Expect 'conversation_uuid' parameter to be a String") unless conversation_uuid.is_a?(String)
+    end
+  end
+end

--- a/lib/vonage/voice/validators/update_call.rb
+++ b/lib/vonage/voice/validators/update_call.rb
@@ -1,0 +1,56 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module Vonage
+  class Voice::Validators::UpdateCall < Namespace
+    attr_accessor :action, :destination
+
+    def initialize(params = {})
+      @action = params.fetch(:action)
+      @destination = params.fetch(:destination, nil)
+
+      after_initialize!(self)
+    end
+
+    def after_initialize!(builder)
+      validate_no_params_conflict(builder)
+      validate_required_params_data(builder)
+    end
+
+    def validate_no_params_conflict(builder)
+      if builder.destination && builder.action != 'transfer'
+        raise ClientError.new("Expect 'destination' parameter only when the 'action' parameter is 'transfer'")
+      end
+    end
+
+    def validate_required_params_data(builder)
+      validate_action_params(builder.action)
+      validate_destination_params(builder.destination) if builder.destination
+    end
+
+    def validate_action_params(action_param)
+      valid_actions = ['transfer', 'hangup', 'mute', 'unmute', 'earmuff', 'unearmuff']
+
+      raise ClientError.new("Expect 'action' parameter to be a String") unless action_param.is_a?(String)
+      raise ClientError.new("Expect 'action' parameter to be one of: " \
+        "#{valid_actions.map{|action| "\"#{action}\""}.join(',')}"
+      ) unless valid_actions.include?(action_param)
+    end
+
+    def validate_destination_params(destination_param)
+      raise ClientError.new("Expect 'destination' parameter to be a Hash") unless destination_param.is_a?(Hash)
+      raise ClientError.new("Expected 'destination' parameter to only have two keys: 'type' and either 'answer_url' or 'ncco'") if destination_param.keys.count > 2
+      raise ClientError.new("Expected a String for the value of 'type'") if !destination_param[:type].is_a?(String)
+
+      if destination_param[:ncco]
+        raise ClientError.new("Expected 'ncco' parameter to be an Array") unless destination_param[:ncco].is_a?(Array)
+      end
+      
+      if destination_param[:url]
+        raise ClientError.new("Expected 'url' parameter to be an Array") unless destination_param[:url].is_a?(Array)
+        raise ClientError.new("Expected only one item in 'url' parameter Array") unless destination_param[:url].length == 1
+        raise ClientError.new("Expected item value in 'url' parameter to be a String") unless destination_param[:url][0].is_a?(String)
+      end
+    end
+  end
+end

--- a/test/vonage/voice/validators/create_call_test.rb
+++ b/test/vonage/voice/validators/create_call_test.rb
@@ -1,0 +1,316 @@
+# typed: false
+
+class Vonage::Voice::Validators::CreateCallTest < Vonage::Test
+  def test_with_only_required_params_and_answer_url
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.to, params[:to]
+    assert_equal builder.from, params[:from]
+    assert_equal builder.answer_url, params[:answer_url]
+  end
+
+  def test_with_only_required_params_and_ncco
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}]
+    }
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.to, params[:to]
+    assert_equal builder.from, params[:from]
+    assert_equal builder.ncco, params[:ncco]
+  end
+
+  def test_with_missing_to_param
+    params = {
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+        
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "key not found: :to", exception.message
+  end
+
+  def test_with_missing_from_param
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      ncco: [{action: 'talk', text: 'test text'}]
+    }
+        
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "key not found: :from", exception.message
+  end
+
+  def test_with_missing_ncco_and_answer_url_param
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected either 'answer_url' or 'ncco' parameter to be provided", exception.message
+  end
+
+  def test_with_required_params_and_both_answer_url_and_ncco
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      answer_url: ['https://example.com/answer']
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected either 'ncco' param or 'answer_url' param, not both", exception.message    
+  end
+
+  def test_with_event_url_param
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_url: ['https://example.com/event']
+    }
+
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.event_url, params[:event_url]
+    assert_kind_of Array, builder.event_url
+    assert_kind_of String, builder.event_url[0]
+    assert builder.event_url.length == 1
+  end
+
+  def test_with_event_url_wrong_object_type
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_url: 'https://example.com/event'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'event_url' parameter to be an Array", exception.message 
+  end
+
+  def test_with_event_url_wrong_item_type
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_url: [{url: 'https://example.com/event'}]
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected value of 'event_url' parameter to be a String", exception.message 
+  end
+
+  def test_with_event_url_wrong_array_size
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_url: ['https://example.com/event', 'https://example.com/event_two']
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected only one String value of 'event_url' parameter", exception.message 
+  end
+
+  def test_with_event_method
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_method: 'GET'
+    }
+
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.event_method, params[:event_method]
+    assert_kind_of String, builder.event_method
+  end
+
+  def test_with_event_method_wrong_object_type
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_method: ['GET']
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected value of 'event_method' parameter to be a String", exception.message 
+  end
+
+  def test_with_event_method_wrong_value
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      event_method: 'PUT'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected value of 'event_method' parameter to be either 'GET' or 'POST'", exception.message 
+  end
+
+  def test_with_ringing_timer_param
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      ringing_timer: 30
+    }
+
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.ringing_timer, params[:ringing_timer]
+    assert_kind_of Integer, builder.ringing_timer
+  end
+
+  def test_with_ringing_timer_wrong_object_type
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      ringing_timer: 'thirty'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'ringing_timer' parameter to be an Integer", exception.message 
+  end
+
+  def test_with_ringing_timer_too_small_value
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      ringing_timer: 0
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'ringing_timer' parameter to be between 1 and 120", exception.message 
+  end
+
+  def test_with_ringing_timer_too_large_value
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      ringing_timer: 121
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'ringing_timer' parameter to be between 1 and 120", exception.message 
+  end
+
+  def test_with_length_timer_param
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      length_timer: 30
+    }
+
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.length_timer, params[:length_timer]
+    assert_kind_of Integer, builder.length_timer
+  end
+
+  def test_with_length_timer_wrong_object_type
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      length_timer: 'thirty'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'length_timer' parameter to be an Integer", exception.message 
+  end
+
+  def test_with_length_timer_too_small_value
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      length_timer: 0
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'length_timer' parameter to be between 1 and 7200", exception.message 
+  end
+
+  def test_with_length_timer_too_large_value
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      length_timer: 7201
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected 'length_timer' parameter to be between 1 and 7200", exception.message 
+  end
+
+  def test_with_machine_detection
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      machine_detection: 'continue'
+    }
+
+    builder = Vonage::Voice::Validators::CreateCall.new(params)
+
+    assert_equal builder.machine_detection, params[:machine_detection]
+    assert_kind_of String, builder.machine_detection
+  end
+
+  def test_with_machine_detection_wrong_object_type
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      machine_detection: ['hangup']
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected value of 'machine_detection' parameter to be a String", exception.message 
+  end
+
+  def test_with_machine_detection_wrong_value
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      ncco: [{action: 'talk', text: 'test text'}],
+      machine_detection: 'transfer'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::CreateCall.new(params) }
+
+    assert_match "Expected value of 'machine_detection' parameter to be either 'continue' or 'hangup'", exception.message 
+  end
+end

--- a/test/vonage/voice/validators/list_calls_test.rb
+++ b/test/vonage/voice/validators/list_calls_test.rb
@@ -1,0 +1,141 @@
+# typed: false
+
+class Vonage::Voice::Validators::ListCallsTest < Vonage::Test
+  def test_with_no_params
+    builder = Vonage::Voice::Validators::ListCalls.new
+
+    assert builder
+  end
+
+  def test_with_all_params
+    params = {
+      status: 'started',
+      date_start: '2020-07-26',
+      date_end: '2020-07-29',
+      page_size: 10,
+      record_index: 2,
+      order: 'asc',
+      conversation_uuid: 'CON-f972836a-550f-45fa-956c-12a2ab5b7d22'
+    }
+
+    builder = Vonage::Voice::Validators::ListCalls.new(params)
+
+    assert_equal builder.status, params[:status]
+    assert_equal builder.date_start, params[:date_start]
+    assert_equal builder.date_end, params[:date_end]
+    assert_equal builder.page_size, params[:page_size]
+    assert_equal builder.record_index, params[:record_index]
+    assert_equal builder.order, params[:order]
+    assert_equal builder.conversation_uuid, params[:conversation_uuid]
+  end
+
+  def test_with_incorrect_status_param_type
+    params = {
+      status: 123
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'status' parameter to be a String", exception.message
+  end
+
+  def test_with_incorrect_status_param_value
+    params = {
+      status: 'frozen'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'status' parameter to be one of: \"started\",\"ringing\",\"answered\",\"machine\",\"completed\",\"busy\",\"cancelled\",\"failed\",\"rejected\",\"timeout\",\"unanswered\"", exception.message
+  end
+
+  def test_with_incorrect_date_start_param_object_type
+    params = {
+      date_start: 123
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'date_start' parameter to be a String", exception.message
+  end
+
+  def test_with_incorrect_date_start_param_date_format
+    params = {
+      date_start: 'May 12 2020 08:35am'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'date_start' parameter to be in ISO8601 format", exception.message
+  end
+
+  def test_with_incorrect_date_end_param_object_type
+    params = {
+      date_end: 123
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'date_end' parameter to be a String", exception.message
+  end
+
+  def test_with_incorrect_date_end_param_date_format
+    params = {
+      date_end: 'May 12 2020 08:35am'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'date_end' parameter to be in ISO8601 format", exception.message
+  end
+
+  def test_with_incorrect_page_size_type
+    params = {
+      page_size: '12'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'page_size' parameter to be an Integer", exception.message
+  end
+
+  def test_with_incorrect_record_index_type
+    params = {
+      record_index: '12'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'record_index' parameter to be an Integer", exception.message
+  end
+
+  def test_with_incorrect_order_param_type
+    params = {
+      order: 123
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'order' parameter to be a String", exception.message
+  end
+
+  def test_with_incorrect_order_param_value
+    params= {
+      order: 'upwards'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'order' parameter value to be either 'asc' or 'desc'", exception.message
+  end
+
+  def test_with_incorrect_conversation_uuid_param_type
+    params = {
+      conversation_uuid: 123
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::ListCalls.new(params) }
+
+    assert_match "Expect 'conversation_uuid' parameter to be a String", exception.message
+  end
+end

--- a/test/vonage/voice/validators/update_call_test.rb
+++ b/test/vonage/voice/validators/update_call_test.rb
@@ -1,0 +1,132 @@
+# typed: false
+
+class Vonage::Voice::Validators::UpdateCallTest < Vonage::Test
+  def test_with_required_params_action_and_destination
+    params = {
+      action: 'transfer',
+      destination: {type: 'ncco', ncco: [{action: 'talk', text: 'test text'}]}
+    }
+    builder = Vonage::Voice::Validators::UpdateCall.new(params)
+
+    assert_equal builder.action, params[:action]
+    assert_equal builder.destination, params[:destination]
+  end
+
+  def test_with_required_params_only_action
+    params = {
+      action: 'hangup'
+    }
+    builder = Vonage::Voice::Validators::UpdateCall.new(params)
+
+    assert_equal builder.action, params[:action]
+    assert_nil builder.destination
+  end
+
+  def test_with_params_conflict
+    params = {
+      action: 'hangup',
+      destination: {type: 'ncco', ncco: [{action: 'talk', text: 'test text'}]}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expect 'destination' parameter only when the 'action' parameter is 'transfer'", exception.message
+  end
+
+  def test_action_param_incorrect_object_type
+    params = {
+      action: ['hangup']
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expect 'action' parameter to be a String", exception.message
+  end
+
+  def test_action_param_raise_incorrect_value
+    params = {
+      action: 'pause'
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expect 'action' parameter to be one of: \"transfer\",\"hangup\",\"mute\",\"unmute\",\"earmuff\",\"unearmuff\"", exception.message
+  end
+
+  def test_destination_param_incorrect_object_type
+    params = {
+      action: 'transfer',
+      destination: [{type: 'ncco', ncco: [{action: 'talk', text: 'test text'}]}]
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expect 'destination' parameter to be a Hash", exception.message
+  end
+
+  def test_destination_param_incorrect_number_of_keys
+    params = {
+      action: 'transfer',
+      destination: {type: 'ncco', ncco: [{action: 'talk', text: 'test text'}], third_key: 'too many keys'}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expected 'destination' parameter to only have two keys: 'type' and either 'answer_url' or 'ncco'", exception.message
+  end
+
+  def test_destination_param_type_field_object_type
+    params = {
+      action: 'transfer',
+      destination: {type: 3, ncco: [{action: 'talk', text: 'test text'}]}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expected a String for the value of 'type'", exception.message
+  end
+
+  def test_destination_param_with_ncco_field
+    params = {
+      action: 'transfer',
+      destination: {type: 'ncco', ncco: {action: 'talk', text: 'test text'}}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expected 'ncco' parameter to be an Array", exception.message
+  end
+
+  def test_destination_param_with_url_field_wrong_type
+    params = {
+      action: 'transfer',
+      destination: {type: 'ncco', url: 'https://example.com/transfer'}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expected 'url' parameter to be an Array", exception.message
+  end
+
+  def test_destination_param_with_url_field_too_many_items
+    params = {
+      action: 'transfer',
+      destination: {type: 'ncco', url: ['https://example.com/transfer', 'second item']}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expected only one item in 'url' parameter Array", exception.message
+  end
+
+  def test_destination_param_with_url_field_wrong_type_for_item
+    params = {
+      action: 'transfer',
+      destination: {type: 'ncco', url: [12345]}
+    }
+
+    exception = assert_raises { Vonage::Voice::Validators::UpdateCall.new(params) }
+
+    assert_match "Expected item value in 'url' parameter to be a String", exception.message
+  end
+end


### PR DESCRIPTION
This is a draft PR experimenting with adding validators for API actions. This is pending a discussion in the SDK team about how much validation the SDKs should do over and above what the APIs do.