### PR TITLE
Remove usage of `T.nilable(T.untyped)`

### DIFF
--- a/lib/vonage/config.rb
+++ b/lib/vonage/config.rb
@@ -200,7 +200,7 @@ module Vonage
 
     protected
 
-    sig { params(name: Symbol, value: T.nilable(T.untyped)).void }
+    sig { params(name: Symbol, value: T.untyped).void }
     def write_attribute(name, value)
       public_send(:"#{name}=", value)
     end


### PR DESCRIPTION
Starting with https://github.com/sorbet/sorbet/pull/5129, using `T.nilable(T.untyped)` is considered an error by Sorbet.