### PR TITLE
Updating CI action to target main and dev branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ 7.x ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ 7.x ]
+    branches: [ main, dev ]
 
 jobs:
   test:


### PR DESCRIPTION
Updating GitHub action in `CI.yml` to target `main` and `dev` branches following change of name of default branch from `7.x` to `main` and creation of `dev` branch.