### PR TITLE
Release v7.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ 7.x ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ 7.x ]
+    branches: [ main, dev ]
 
 jobs:
   test:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.4.1
+
+* Bug fix: updated `sorbet` signature to fix issue with `T.nilable(T.untyped)`. See issue [#200](https://github.com/Vonage/vonage-ruby-sdk/issues/200) and PR [#199](https://github.com/Vonage/vonage-ruby-sdk/pull/199). Thanks to [@KaanOzkan](https://github.com/KaanOzkan) and [@vinistock](https://github.com/vinistock)
+
 # 7.4.0
 
 * Added new NCCO builder functionality for constructing Voice API actions

--- a/lib/vonage/config.rb
+++ b/lib/vonage/config.rb
@@ -200,7 +200,7 @@ module Vonage
 
     protected
 
-    sig { params(name: Symbol, value: T.nilable(T.untyped)).void }
+    sig { params(name: Symbol, value: T.untyped).void }
     def write_attribute(name, value)
       public_send(:"#{name}=", value)
     end

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.4.0'
+  VERSION = '7.4.1'
 end


### PR DESCRIPTION
Changes in this PR:

- Fix for `sorbet` signature: https://github.com/Vonage/vonage-ruby-sdk/pull/199
- Update CI action following branch name changes/ additions: https://github.com/Vonage/vonage-ruby-sdk/pull/201