### PR TITLE
Exposes response context in case of API error response

### DIFF
--- a/lib/vonage/number_insight.rb
+++ b/lib/vonage/number_insight.rb
@@ -25,7 +25,7 @@ module Vonage
     def basic(params)
       response = request('/ni/basic/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ResponseError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end
@@ -57,7 +57,7 @@ module Vonage
     def standard(params)
       response = request('/ni/standard/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ResponseError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end
@@ -93,7 +93,7 @@ module Vonage
     def advanced(params)
       response = request('/ni/advanced/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ResponseError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end
@@ -132,7 +132,7 @@ module Vonage
     def advanced_async(params)
       response = request('/ni/advanced/async/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ResponseError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end

--- a/lib/vonage/response_error.rb
+++ b/lib/vonage/response_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Vonage
+  class ResponseError < Error
+    attr_reader :response
+
+    def initialize(message, response:)
+      @response = response
+      super(message)
+    end
+  end
+end

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -105,7 +105,7 @@ module Vonage
       response = request('/sms/json', params: hyphenate(params), type: Post)
 
       unless response.messages.first.status == '0'
-        raise Error, response.messages.first[:error_text]
+        raise ResponseError.new(response.messages.first[:error_text], response: response)
       end
 
       response

--- a/lib/vonage/verify.rb
+++ b/lib/vonage/verify.rb
@@ -64,7 +64,7 @@ module Vonage
     def request(params, uri = '/verify/json')
       response = http_request(uri, params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ResponseError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -97,7 +97,7 @@ module Vonage
     def check(params)
       response = http_request('/verify/check/json', params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ResponseError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -124,7 +124,7 @@ module Vonage
     def search(params)
       response = http_request('/verify/search/json', params: params)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ResponseError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -151,7 +151,7 @@ module Vonage
     def control(params)
       response = http_request('/verify/control/json', params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ResponseError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -238,7 +238,7 @@ module Vonage
     def psd2(params, uri = '/verify/psd2/json')
       response = http_request(uri, params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ResponseError.new(response[:error_text], response: response) if error?(response)
 
       response
     end


### PR DESCRIPTION
## Context

Since the `7.0.0` release, we're not able anymore to properly handle Vonage response errors.

For example, before the `7.0.0` release, with the `number_insight` API , we were able to handle response errors like

```ruby
response = client.number_insight.standard(params)

case response.status
when '0'
  handle_success(response)
when '44'
  handle_lookup_handler_error(response)
else
  handle_error(response)
end
```

Since the `7.0.0`, in case of this kind of errors, it raises a generic `Vonage::Error` without exposing any response context, which means we're not able anymore to properly handle API responses

## Implementation choice

- Added a specific `Vonage::ResponseError` which exposes the `Vonage::Response` as `response` attribute
- Raise this specifc `Vonage::ResponseError` instead of the generic `Vonage::Error` when relevant (`number_insight`, `sms` and `verify` APIs)

We're now able to handle API response errors like

```ruby
begin
  response = client.number_insight.standard(params)
  handle_success(response)
rescue Vonage::ServerError
  # Do something
rescue Vonage::ClientError
  # Do something else
rescue Vonage::ResponseError => e
  case e.response.status
  when '44'
    handle_lookup_handler_error(e.response)
  else
    handle_error(e.response)
  end
rescue Vonage::Error
  # World is broken
end
```

This won't change anything to the current behavior, only adds the ability to rescue the specific `Vonage::ResponseError` which will give more response context

NB: I didn't updated the specs to ensure that the current behavior is not broken

## Links

- #197 