### PR TITLE
Fix Vonage::Voice::Ncco class method definition

### DIFF
--- a/lib/vonage/voice/ncco.rb
+++ b/lib/vonage/voice/ncco.rb
@@ -13,9 +13,11 @@ module Vonage
       talk: Vonage::Voice::Actions::Talk
     }
 
-    ACTIONS.keys.each do |method|      
-      self.class.send :define_method, method do |attributes|
-        ACTIONS[method].new(**attributes).action
+    class << self
+      ACTIONS.keys.each do |method|
+        define_method method do |attributes|
+          ACTIONS[method].new(**attributes).action
+        end
       end
     end
 

--- a/test/vonage/voice/ncco_test.rb
+++ b/test/vonage/voice/ncco_test.rb
@@ -22,4 +22,11 @@ class Vonage::Voice::NccoTest < Vonage::Test
     
     assert_match "NCCO action must be one of the valid options. Please refer to https://developer.nexmo.com/voice/voice-api/ncco-reference#ncco-actions for a complete list.", exception.message
   end
+
+  Vonage::Voice::Ncco::ACTIONS.keys.each do |method_name|
+    define_method "test_ncco_#{method_name}_defined_class_method" do
+      assert_respond_to ncco, method_name
+      refute_respond_to ncco.class, method_name
+    end
+  end
 end


### PR DESCRIPTION
## Context

As described in the issue #205,  since the `Vonage::Voice::Ncco` was introduced in the `7.4.0` version, it could lead with a conflict with any other class implementing one of these class method names

https://github.com/Vonage/vonage-ruby-sdk/blob/ecb5dbd9d288dbb6f50f8fb97f2f56603b185916/lib/vonage/voice/ncco.rb#L6-L14

The issue is located here

https://github.com/Vonage/vonage-ruby-sdk/blob/ecb5dbd9d288dbb6f50f8fb97f2f56603b185916/lib/vonage/voice/ncco.rb#L17

Since this code is called at the class level, `self.class` is `Class` (and not the expected `Vonage::Voice::Ncco` class), which means methods are defined in the native ruby class `Class`. Since all classes are a `Class`, this methods could conflict with any other class (from another library, or from the project) that are implementing one of these method names depending on the load order.

## Links

- Issue #205 