### PR TITLE
DEVX-5866: Adding response context to some exceptions

### DIFF
--- a/lib/vonage/number_insight.rb
+++ b/lib/vonage/number_insight.rb
@@ -25,7 +25,7 @@ module Vonage
     def basic(params)
       response = request('/ni/basic/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response: response), response[:status_message] unless response.status.zero?
 
       response
     end
@@ -57,7 +57,7 @@ module Vonage
     def standard(params)
       response = request('/ni/standard/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response: response), response[:status_message] unless response.status.zero?
 
       response
     end
@@ -93,7 +93,7 @@ module Vonage
     def advanced(params)
       response = request('/ni/advanced/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response: response), response[:status_message] unless response.status.zero?
 
       response
     end
@@ -132,7 +132,7 @@ module Vonage
     def advanced_async(params)
       response = request('/ni/advanced/async/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response: response), response[:status_message] unless response.status.zero?
 
       response
     end

--- a/lib/vonage/service_error.rb
+++ b/lib/vonage/service_error.rb
@@ -1,0 +1,16 @@
+# typed: strong
+
+module Vonage
+  class ServiceError < Error
+    extend T::Sig
+
+    sig { returns(Vonage::Response) }
+    attr_reader :response
+
+    sig { params(message: T.nilable(String), response: Vonage::Response).void }
+    def initialize(message = nil, response:)
+      super(message)
+      @response = response
+    end
+  end
+end

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -105,7 +105,7 @@ module Vonage
       response = request('/sms/json', params: hyphenate(params), type: Post)
 
       unless response.messages.first.status == '0'
-        raise Error, response.messages.first[:error_text]
+        raise ServiceError.new(response: response), response.messages.first[:error_text]
       end
 
       response

--- a/lib/vonage/verify.rb
+++ b/lib/vonage/verify.rb
@@ -64,7 +64,7 @@ module Vonage
     def request(params, uri = '/verify/json')
       response = http_request(uri, params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response: response), response[:error_text] if error?(response)
 
       response
     end
@@ -97,7 +97,7 @@ module Vonage
     def check(params)
       response = http_request('/verify/check/json', params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response: response), response[:error_text] if error?(response)
 
       response
     end
@@ -124,7 +124,7 @@ module Vonage
     def search(params)
       response = http_request('/verify/search/json', params: params)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response: response), response[:error_text] if error?(response)
 
       response
     end
@@ -151,7 +151,7 @@ module Vonage
     def control(params)
       response = http_request('/verify/control/json', params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response: response), response[:error_text] if error?(response)
 
       response
     end
@@ -234,11 +234,11 @@ module Vonage
     #
     # @see https://developer.nexmo.com/api/verify#verifyRequestWithPSD2
     #
-    sig { params(params: T.untyped, uri: T.untyped).returns(T.any(Vonage::Error, Vonage::Response)) }
+    sig { params(params: T.untyped, uri: T.untyped).returns(T.any(Vonage::ServiceError, Vonage::Response)) }
     def psd2(params, uri = '/verify/psd2/json')
       response = http_request(uri, params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response: response), response[:error_text] if error?(response)
 
       response
     end

--- a/test/vonage/number_insight_test.rb
+++ b/test/vonage/number_insight_test.rb
@@ -35,9 +35,12 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.basic(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.basic(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_standard_method
@@ -47,9 +50,12 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.standard(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.standard(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_advanced_method
@@ -59,9 +65,12 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.advanced(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.advanced(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_advanced_async_method
@@ -71,8 +80,11 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.advanced_async(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.advanced_async(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 end

--- a/test/vonage/sms_test.rb
+++ b/test/vonage/sms_test.rb
@@ -31,9 +31,12 @@ class Vonage::SMSTest < Vonage::Test
 
     assert_kind_of Vonage::Response, sms.send(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       sms.send(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_mapping_underscored_keys_to_hyphenated_string_keys

--- a/test/vonage/verify_test.rb
+++ b/test/vonage/verify_test.rb
@@ -33,9 +33,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.request(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.request(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_check_method
@@ -47,9 +50,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.check(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.check(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_search_method
@@ -61,9 +67,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.search(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.search(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_control_method
@@ -75,9 +84,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.control(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.control(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_cancel_method
@@ -89,9 +101,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.cancel(request_id)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.cancel(request_id)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_trigger_next_event_method
@@ -103,9 +118,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.trigger_next_event(request_id)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.trigger_next_event(request_id)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_psd2_method
@@ -117,8 +135,11 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.psd2(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.psd2(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 end


### PR DESCRIPTION
## Reason for this PR

Some of the Vonage APIs (Verify, SMS, Number Insight) return a `200` HTTP code even when there is an error, and instead define the error in a `status` property of the response body. The library checks for the value of this property, and raises a `Vonage::Error` exception in a case where it is not `0`. This means that users of the library know that there was an 'error' of some sort on the API side, but do not have access to the value of `status`.

## What this PR does

- Defines a new custom exception class `ServiceError`
  - This error class defines a `response` ivar, which is set to the `Response` object (which provides getters for the properties in the JSON response body).
- Providing access to the response within a specific custom error class means that users of the library can now `rescue` that specific class, check the value of the `status` within the response, and follow some conditional logic based on the value of that status.

See https://github.com/Vonage/vonage-ruby-sdk/pull/204 and https://github.com/Vonage/vonage-ruby-sdk/issues/197 for additional context.
