### PR TITLE
Revert 209 revert 206 fix/fix voice ncco class method definition

### DIFF
--- a/lib/vonage/voice/ncco.rb
+++ b/lib/vonage/voice/ncco.rb
@@ -13,9 +13,11 @@ module Vonage
       talk: Vonage::Voice::Actions::Talk
     }
 
-    ACTIONS.keys.each do |method|      
-      self.class.send :define_method, method do |attributes|
-        ACTIONS[method].new(**attributes).action
+    class << self
+      ACTIONS.keys.each do |method|
+        define_method method do |attributes|
+          ACTIONS[method].new(**attributes).action
+        end
       end
     end
 

--- a/lib/vonage/voice/ncco.rb
+++ b/lib/vonage/voice/ncco.rb
@@ -13,11 +13,9 @@ module Vonage
       talk: Vonage::Voice::Actions::Talk
     }
 
-    class << self
-      ACTIONS.keys.each do |method|
-        define_method method do |attributes|
-          ACTIONS[method].new(**attributes).action
-        end
+    ACTIONS.keys.each do |method|      
+      self.class.send :define_method, method do |attributes|
+        ACTIONS[method].new(**attributes).action
       end
     end
 

--- a/test/vonage/voice/ncco_test.rb
+++ b/test/vonage/voice/ncco_test.rb
@@ -22,4 +22,11 @@ class Vonage::Voice::NccoTest < Vonage::Test
     
     assert_match "NCCO action must be one of the valid options. Please refer to https://developer.nexmo.com/voice/voice-api/ncco-reference#ncco-actions for a complete list.", exception.message
   end
+
+  Vonage::Voice::Ncco::ACTIONS.keys.each do |method_name|
+    define_method "test_ncco_#{method_name}_defined_class_method" do
+      assert_respond_to ncco, method_name
+      refute_respond_to ncco.class, method_name
+    end
+  end
 end

--- a/test/vonage/voice/ncco_test.rb
+++ b/test/vonage/voice/ncco_test.rb
@@ -22,11 +22,4 @@ class Vonage::Voice::NccoTest < Vonage::Test
     
     assert_match "NCCO action must be one of the valid options. Please refer to https://developer.nexmo.com/voice/voice-api/ncco-reference#ncco-actions for a complete list.", exception.message
   end
-
-  Vonage::Voice::Ncco::ACTIONS.keys.each do |method_name|
-    define_method "test_ncco_#{method_name}_defined_class_method" do
-      assert_respond_to ncco, method_name
-      refute_respond_to ncco.class, method_name
-    end
-  end
 end


### PR DESCRIPTION
Merges https://github.com/Vonage/vonage-ruby-sdk/pull/206 into `dev` (was incorrectly merged to `main` then reverted). 