### PR TITLE
Change version to 7.5.0

### DIFF
--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.5.1'
+  VERSION = '7.5.0'
 end


### PR DESCRIPTION
Fixes incorrect version number in https://github.com/Vonage/vonage-ruby-sdk/pull/211