### PR TITLE
Adding 'Accept' header to Namespeace#build_request method

### DIFF
--- a/lib/vonage/namespace.rb
+++ b/lib/vonage/namespace.rb
@@ -71,6 +71,7 @@ module Vonage
 
       # set headers
       request['User-Agent'] = UserAgent.string(@config.app_name, @config.app_version)
+      request['Accept'] = 'application/json'
       self.class.request_headers.each do |key, value|
         request[key] = value
       end


### PR DESCRIPTION
## Reason for this PR

A recent change to the SMS API was sending responses with a `Content-Type` of `text/plain` unless an `Accept` header with a value of `application/json` was sent in the request. Although the change was reverted, it would be prudent to add this header to requests sent from the library.

## What this PR does

- Sets an `Accept` header with a value of `application/json` for all requests. This is done by an update to the `Namespace#build_request` method.

See https://github.com/Vonage/vonage-ruby-sdk/issues/216 for additional context.
