### PR TITLE
DEVX-6027:  Add Messages API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,32 @@ response = client.voice.create({
 })
 ```
 
+## Messages API
+
+The [Vonage Messages API](https://developer.vonage.com/messages/overview) allows you to send messages over a number of different channels, and various message types within each channel. See the Vonage Developer Documentation for a [complete API reference](https://developer.vonage.com/api/messages-olympus) listing all the channel and message type combinations.
+
+The Ruby SDK allows you to construct message data for specific messaging channels. Other than SMS (which has only one type -- text), you need to pass the message `:type` as well as the `:message` itself as arguments to the appropriate messages method, along with any optional properties if needed.
+
+```ruby
+# creating an SMS message
+message = Vonage::Messaging::Message.sms(message: 'Hello world!')
+
+# creating a WhatsApp Text message
+message = Vonage::Messaging::Message.whatsapp(type: 'text', message: 'Hello world!')
+
+# creating a WhatsApp Image message
+message = Vonage::Messaging::Message.whatsapp(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+# creating an MMS audio message with optional properties
+message = Vonage::Messaging::Message.mms(type: 'audio', message: { url: 'https://example.com/audio.mp3' }, opts: {client_ref: "abc123"})
+```
+
+Once the message data is created, you can then send the message.
+
+```ruby
+response = client.messaging.send(to: "447700900000", from: "447700900001", **message)
+```
+
 ## Documentation
 
 Vonage Ruby documentation: https://www.rubydoc.info/github/Vonage/vonage-ruby-sdk

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ By default the hosts are set to `api.nexmo.com` and `rest.nexmo.com`, respective
 
 ## JWT authentication
 
-To call newer endpoints that support JWT authentication such as the Voice API you'll
+To call newer endpoints that support JWT authentication such as the Voice API and Messages API you'll
 also need to specify the `application_id` and `private_key` options. For example:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The following is a list of Vonage APIs and whether the Ruby SDK provides support
 | Dispatch API | Beta |❌|
 | External Accounts API | Beta |❌|
 | Media API | Beta | ❌|
-| Messages API | Beta |❌|
+| Messages API | General Availability |✅|
 | Number Insight API | General Availability |✅|
 | Number Management API | General Availability |✅|
 | Pricing API | General Availability |✅|

--- a/lib/vonage.rb
+++ b/lib/vonage.rb
@@ -13,6 +13,7 @@ module Vonage
     'json' => 'JSON',
     'jwt' => 'JWT',
     'sms' => 'SMS',
+    'mms' => 'MMS',
     'tfa' => 'TFA',
     'version' => 'VERSION',
   })

--- a/lib/vonage/client.rb
+++ b/lib/vonage/client.rb
@@ -68,6 +68,13 @@ module Vonage
       @messages ||= T.let(Messages.new(config), T.nilable(Vonage::Messages))
     end
 
+    # @return [Messaging]
+    #
+    sig { returns(T.nilable(Vonage::Messaging)) }
+    def messaging
+      @messaging ||= T.let(Messaging.new(config), T.nilable(Vonage::Messaging))
+    end
+
     # @return [NumberInsight]
     #
     sig { returns(T.nilable(Vonage::NumberInsight)) }

--- a/lib/vonage/messaging.rb
+++ b/lib/vonage/messaging.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+module Vonage
+  class Messaging < Namespace
+    self.authentication = BearerToken
+
+    self.request_body = JSON
+
+    # Send a Message.
+    #
+    # @example
+    #   message = Vonage::Messaging::Message.sms(message: "Hello world!")
+    #   response = client.messaging.send(to: "447700900000", from: "447700900001", **message)
+    #
+    # @option params [required, String] :to
+    #
+    # @option params [required, String] :from
+    #
+    # @option params [required, Hash] **message
+    #   The Vonage Message object to use for this message.
+    #
+    # @see https://developer.vonage.com/api/messages-olympus#SendMessage
+    #
+    def send(params)
+      request('/v1/messages', params: params, type: Post)
+    end
+  end
+end

--- a/lib/vonage/messaging/channels/messenger.rb
+++ b/lib/vonage/messaging/channels/messenger.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module Vonage
-  class Messaging::Channels::Messenger
+  class Messaging::Channels::Messenger < Messaging::Message
     MESSAGE_TYPES = ['text', 'image', 'audio', 'video', 'file']
 
     attr_reader :data
@@ -17,20 +17,9 @@ module Vonage
 
     private
 
-    attr_accessor :type, :message, :opts
-    attr_writer :data
-
-    def after_initialize!
-      verify_type
-      verify_message
-      build
-    end
-
     def build
       data[:channel] = 'messenger'
-      data[:message_type] = type
-      data[type.to_sym] = message
-      data.merge!(opts)
+      super
     end
 
     def verify_type

--- a/lib/vonage/messaging/channels/messenger.rb
+++ b/lib/vonage/messaging/channels/messenger.rb
@@ -1,0 +1,50 @@
+# typed: true
+
+module Vonage
+  class Messaging::Channels::Messenger
+    MESSAGE_TYPES = ['text', 'image', 'audio', 'video', 'file']
+
+    attr_reader :data
+
+    def initialize(attributes = {})
+      @type = attributes.fetch(:type, nil)
+      @message = attributes.fetch(:message, nil)
+      @opts = attributes.fetch(:opts, {})
+      @data = {}
+
+      after_initialize!
+    end
+
+    private
+
+    attr_accessor :type, :message, :opts
+    attr_writer :data
+
+    def after_initialize!
+      verify_type
+      verify_message
+      build
+    end
+
+    def build
+      data[:channel] = 'messenger'
+      data[:message_type] = type
+      data[type.to_sym] = message
+      data.merge!(opts)
+    end
+
+    def verify_type
+      raise Vonage::ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
+    end
+
+    def verify_message
+      case type
+      when 'text'
+        raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
+      else
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
+      end
+    end
+  end
+end

--- a/lib/vonage/messaging/channels/mms.rb
+++ b/lib/vonage/messaging/channels/mms.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module Vonage
-  class Messaging::Channels::MMS
+  class Messaging::Channels::MMS < Messaging::Message
     MESSAGE_TYPES = ['image', 'vcard', 'audio', 'video']
 
     attr_reader :data
@@ -17,20 +17,9 @@ module Vonage
 
     private
 
-    attr_accessor :type, :message, :opts
-    attr_writer :data
-
-    def after_initialize!
-      verify_type
-      verify_message
-      build
-    end
-
     def build
       data[:channel] = 'mms'
-      data[:message_type] = type
-      data[type.to_sym] = message
-      data.merge!(opts)
+      super
     end
 
     def verify_type

--- a/lib/vonage/messaging/channels/mms.rb
+++ b/lib/vonage/messaging/channels/mms.rb
@@ -34,12 +34,12 @@ module Vonage
     end
 
     def verify_type
-      raise ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
+      raise Vonage::ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
     end
 
     def verify_message
-      raise ClientError.new(":message must be a Hash") unless message.is_a? Hash
-      raise ClientError.new(":url is required in :message") unless message[:url]
+      raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+      raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
     end
   end
 end

--- a/lib/vonage/messaging/channels/mms.rb
+++ b/lib/vonage/messaging/channels/mms.rb
@@ -1,0 +1,45 @@
+# typed: true
+
+module Vonage
+  class Messaging::Channels::MMS
+    MESSAGE_TYPES = ['image', 'vcard', 'audio', 'video']
+
+    attr_reader :data
+
+    def initialize(attributes = {})
+      @type = attributes.fetch(:type, nil)
+      @message = attributes.fetch(:message, nil)
+      @opts = attributes.fetch(:opts, {})
+      @data = {}
+
+      after_initialize!
+    end
+
+    private
+
+    attr_accessor :type, :message, :opts
+    attr_writer :data
+
+    def after_initialize!
+      verify_type
+      verify_message
+      build
+    end
+
+    def build
+      data[:channel] = 'mms'
+      data[:message_type] = type
+      data[type.to_sym] = message
+      data.merge!(opts)
+    end
+
+    def verify_type
+      raise ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
+    end
+
+    def verify_message
+      raise ClientError.new(":message must be a Hash") unless message.is_a? Hash
+      raise ClientError.new(":url is required in :message") unless message[:url]
+    end
+  end
+end

--- a/lib/vonage/messaging/channels/sms.rb
+++ b/lib/vonage/messaging/channels/sms.rb
@@ -1,0 +1,42 @@
+# typed: true
+
+module Vonage
+  class Messaging::Channels::SMS
+    attr_reader :data
+
+    def initialize(attributes = {})
+      @type = attributes.fetch(:type, 'text')
+      @message = attributes.fetch(:message, nil)
+      @opts = attributes.fetch(:opts, {})
+      @data = {}
+
+      after_initialize!
+    end
+
+    private
+
+    attr_accessor :type, :message, :opts
+    attr_writer :data
+
+    def after_initialize!
+      verify_type
+      verify_message
+      build
+    end
+
+    def build
+      data[:channel] = 'sms'
+      data[:message_type] = type
+      data[type.to_sym] = message
+      data.merge!(opts)
+    end
+
+    def verify_type
+      raise Vonage::ClientError.new("Invalid message type") unless type == 'text'
+    end
+
+    def verify_message
+      raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
+    end
+  end
+end

--- a/lib/vonage/messaging/channels/sms.rb
+++ b/lib/vonage/messaging/channels/sms.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module Vonage
-  class Messaging::Channels::SMS
+  class Messaging::Channels::SMS < Messaging::Message
     attr_reader :data
 
     def initialize(attributes = {})
@@ -15,20 +15,9 @@ module Vonage
 
     private
 
-    attr_accessor :type, :message, :opts
-    attr_writer :data
-
-    def after_initialize!
-      verify_type
-      verify_message
-      build
-    end
-
     def build
       data[:channel] = 'sms'
-      data[:message_type] = type
-      data[type.to_sym] = message
-      data.merge!(opts)
+      super
     end
 
     def verify_type

--- a/lib/vonage/messaging/channels/viber.rb
+++ b/lib/vonage/messaging/channels/viber.rb
@@ -38,7 +38,7 @@ module Vonage
     end
 
     def verify_message
-      case self.type
+      case type
       when 'text'
         raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
       when 'image'

--- a/lib/vonage/messaging/channels/viber.rb
+++ b/lib/vonage/messaging/channels/viber.rb
@@ -1,0 +1,50 @@
+# typed: true
+
+module Vonage
+  class Messaging::Channels::Viber
+    MESSAGE_TYPES = ['text', 'image']
+
+    attr_reader :data
+
+    def initialize(attributes = {})
+      @type = attributes.fetch(:type, nil)
+      @message = attributes.fetch(:message, nil)
+      @opts = attributes.fetch(:opts, {})
+      @data = {}
+
+      after_initialize!
+    end
+
+    private
+
+    attr_accessor :type, :message, :opts
+    attr_writer :data
+
+    def after_initialize!
+      verify_type
+      verify_message
+      build
+    end
+
+    def build
+      data[:channel] = ' viber_service'
+      data[:message_type] = type
+      data[type.to_sym] = message
+      data.merge!(opts)
+    end
+
+    def verify_type
+      raise ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
+    end
+
+    def verify_message
+      case self.type
+      when 'text'
+        raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
+      when 'image'
+        raise ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise ClientError.new(":url is required in :message") unless message[:url]
+      end
+    end
+  end
+end

--- a/lib/vonage/messaging/channels/viber.rb
+++ b/lib/vonage/messaging/channels/viber.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module Vonage
-  class Messaging::Channels::Viber
+  class Messaging::Channels::Viber  < Messaging::Message
     MESSAGE_TYPES = ['text', 'image']
 
     attr_reader :data
@@ -17,20 +17,9 @@ module Vonage
 
     private
 
-    attr_accessor :type, :message, :opts
-    attr_writer :data
-
-    def after_initialize!
-      verify_type
-      verify_message
-      build
-    end
-
     def build
       data[:channel] = ' viber_service'
-      data[:message_type] = type
-      data[type.to_sym] = message
-      data.merge!(opts)
+      super
     end
 
     def verify_type

--- a/lib/vonage/messaging/channels/viber.rb
+++ b/lib/vonage/messaging/channels/viber.rb
@@ -34,7 +34,7 @@ module Vonage
     end
 
     def verify_type
-      raise ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
+      raise Vonage::ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
     end
 
     def verify_message
@@ -42,8 +42,8 @@ module Vonage
       when 'text'
         raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
       when 'image'
-        raise ClientError.new(":message must be a Hash") unless message.is_a? Hash
-        raise ClientError.new(":url is required in :message") unless message[:url]
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
       end
     end
   end

--- a/lib/vonage/messaging/channels/whats_app.rb
+++ b/lib/vonage/messaging/channels/whats_app.rb
@@ -1,0 +1,58 @@
+# typed: true
+
+module Vonage
+  class Messaging::Channels::WhatsApp
+    MESSAGE_TYPES = ['text', 'image', 'audio', 'video', 'file', 'template', 'custom']
+
+    attr_reader :data
+
+    def initialize(attributes = {})
+      @type = attributes.fetch(:type, nil)
+      @message = attributes.fetch(:message, nil)
+      @opts = attributes.fetch(:opts, {})
+      @data = {}
+
+      after_initialize!
+    end
+
+    private
+
+    attr_accessor :type, :message, :opts
+    attr_writer :data
+
+    def after_initialize!
+      verify_type
+      verify_message
+      build
+    end
+
+    def build
+      data[:channel] = 'whatsapp'
+      data[:message_type] = type
+      data[type.to_sym] = message
+      data.merge!(opts)
+    end
+
+    def verify_type
+      raise ClientError.new("Invalid message type") unless MESSAGE_TYPES.include?(type)
+    end
+
+    def verify_message
+      case type
+      when 'text'
+        raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
+      when 'template'
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new(":name is required in :template") unless message[:name]
+        raise Vonage::ClientError.new(":whatsapp is required in :opts") unless opts[:whatsapp]
+        raise Vonage::ClientError.new(":policy is required in :whatsapp") unless opts[:whatsapp][:policy]
+        raise Vonage::ClientError.new(":locale is required in :whatsapp") unless opts[:whatsapp][:locale]
+      when 'custom'
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+      else
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
+      end
+    end
+  end
+end

--- a/lib/vonage/messaging/channels/whats_app.rb
+++ b/lib/vonage/messaging/channels/whats_app.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module Vonage
-  class Messaging::Channels::WhatsApp
+  class Messaging::Channels::WhatsApp < Messaging::Message
     MESSAGE_TYPES = ['text', 'image', 'audio', 'video', 'file', 'template', 'custom']
 
     attr_reader :data
@@ -17,20 +17,9 @@ module Vonage
 
     private
 
-    attr_accessor :type, :message, :opts
-    attr_writer :data
-
-    def after_initialize!
-      verify_type
-      verify_message
-      build
-    end
-
     def build
       data[:channel] = 'whatsapp'
-      data[:message_type] = type
-      data[type.to_sym] = message
-      data.merge!(opts)
+      super
     end
 
     def verify_type

--- a/lib/vonage/messaging/message.rb
+++ b/lib/vonage/messaging/message.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+module Vonage
+  class Messaging::Message
+    CHANNELS = {
+      sms: Vonage::Messaging::Channels::SMS,
+      mms: Vonage::Messaging::Channels::MMS,
+      whatsapp: Vonage::Messaging::Channels::WhatsApp,
+      messenger: Vonage::Messaging::Channels::Messenger,
+      viber: Vonage::Messaging::Channels::Viber
+    }
+
+    class << self
+      CHANNELS.keys.each do |method|
+        define_method method do |attributes|
+          CHANNELS[method].new(**attributes).data
+        end
+      end
+    end
+
+    def self.method_missing(method)
+      raise ClientError.new("Messaging channel must be one of the valid options.")
+    end
+  end
+end

--- a/lib/vonage/messaging/message.rb
+++ b/lib/vonage/messaging/message.rb
@@ -21,5 +21,22 @@ module Vonage
     def self.method_missing(method)
       raise ClientError.new("Messaging channel must be one of the valid options.")
     end
+
+    private
+
+    attr_accessor :type, :message, :opts
+    attr_writer :data
+
+    def after_initialize!
+      verify_type
+      verify_message
+      build
+    end
+
+    def build
+      data[:message_type] = type
+      data[type.to_sym] = message
+      data.merge!(opts)
+    end
   end
 end

--- a/test/vonage/client_test.rb
+++ b/test/vonage/client_test.rb
@@ -42,6 +42,10 @@ class Vonage::ClientTest < Vonage::Test
     assert_kind_of Vonage::Messages, client.messages
   end
 
+  def test_messaging_method
+    assert_kind_of Vonage::Messaging, client.messaging
+  end
+
   def test_number_insight_method
     assert_kind_of Vonage::NumberInsight, client.number_insight
   end

--- a/test/vonage/messaging/channels/messenger_test.rb
+++ b/test/vonage/messaging/channels/messenger_test.rb
@@ -1,0 +1,92 @@
+# typed: false
+
+
+class Vonage::Messaging::Channels::MessengerTest < Vonage::Test
+  def test_messenger_initialize
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!')
+
+    assert_kind_of Vonage::Messaging::Channels::Messenger, messenger
+    assert_equal messenger.data, { channel: 'messenger', message_type: 'text', text: 'Hello world!' }
+  end
+
+  def test_with_valid_type_text_specified
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!')
+
+    assert_equal 'text', messenger.data[:message_type]
+    assert_includes messenger.data, :text
+  end
+
+  def test_with_valid_type_image_specified
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_equal 'image', messenger.data[:message_type]
+    assert_includes messenger.data, :image
+  end
+
+  def test_with_valid_type_audio_specified
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'audio', message: { url: 'https://example.com/audio.mp3' })
+
+    assert_equal 'audio', messenger.data[:message_type]
+    assert_includes messenger.data, :audio
+  end
+
+  def test_with_valid_type_video_specified
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'video', message: { url: 'https://example.com/video.mp4' })
+
+    assert_equal 'video', messenger.data[:message_type]
+    assert_includes messenger.data, :video
+  end
+
+  def test_with_valid_type_file_specified
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'file', message: { url: 'https://example.com/file.pdf' })
+
+    assert_equal 'file', messenger.data[:message_type]
+    assert_includes messenger.data, :file
+  end
+
+  def test_with_invalid_type_specified
+    exception = assert_raises {
+      messenger = Vonage::Messaging::Channels::Messenger.new(type: 'vcard', message: { url: 'https://example.com/contact.vcf' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match "Invalid message type", exception.message
+  end
+
+  def test_with_valid_message_class
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_kind_of Hash, messenger.data[:image]
+  end
+
+  def test_with_invalid_message_class
+    exception = assert_raises {
+      messenger = Vonage::Messaging::Channels::Messenger.new(type: 'image', message: "https://example.com/image.jpg")
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must be a Hash", exception.message
+  end
+
+  def test_object_message_without_url
+    exception = assert_raises {
+      messenger = Vonage::Messaging::Channels::Messenger.new(type: 'image', message: {})
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":url is required in :message", exception.message
+  end
+
+  def test_with_opts_client_ref
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!', opts: { client_ref: 'abc123' })
+
+    assert_equal 'abc123', messenger.data[:client_ref]
+  end
+
+  def test_with_opts_messenger_object
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!', opts: { messenger: { category: 'response', tag: 'CONFIRMED_EVENT_UPDATE' } })
+
+    assert_equal 'response', messenger.data[:messenger][:category]
+    assert_equal 'CONFIRMED_EVENT_UPDATE', messenger.data[:messenger][:tag]
+  end
+end

--- a/test/vonage/messaging/channels/mms_test.rb
+++ b/test/vonage/messaging/channels/mms_test.rb
@@ -1,0 +1,85 @@
+# typed: false
+
+
+class Vonage::Messaging::Channels::MMSTest < Vonage::Test
+  def test_mms_initialize
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_kind_of Vonage::Messaging::Channels::MMS, mms
+    assert_equal mms.data, { channel: 'mms', message_type: 'image', image: { url: 'https://example.com/image.jpg' } }
+  end
+
+  def test_with_valid_type_image_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_equal 'image', mms.data[:message_type]
+    assert_includes mms.data, :image
+  end
+
+  def test_with_valid_type_vcard_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'vcard', message: { url: 'https://example.com/contact.vcf' })
+
+    assert_equal 'vcard', mms.data[:message_type]
+    assert_includes mms.data, :vcard
+  end
+
+  def test_with_valid_type_audio_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'audio', message: { url: 'https://example.com/audio.mp3' })
+
+    assert_equal 'audio', mms.data[:message_type]
+    assert_includes mms.data, :audio
+  end
+
+  def test_with_valid_type_video_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'video', message: { url: 'https://example.com/video.mp4' })
+
+    assert_equal 'video', mms.data[:message_type]
+    assert_includes mms.data, :video
+  end
+
+  def test_with_invalid_type_specified
+    exception = assert_raises {
+      mms = Vonage::Messaging::Channels::MMS.new(type: 'text', message: { url: 'https://example.com/video.mp4' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match "Invalid message type", exception.message
+  end
+
+  def test_with_valid_message_class
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_kind_of Hash, mms.data[:image]
+  end
+
+  def test_with_invalid_message_class
+    exception = assert_raises {
+      mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: "https://example.com/image.jpg")
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must be a Hash", exception.message
+  end
+
+  def test_with_caption
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg', caption: "Additional text to accompany the image." })
+
+    assert_includes mms.data[:image], :caption
+    assert_equal "Additional text to accompany the image.", mms.data[:image][:caption]
+  end
+
+  def test_without_url
+    exception = assert_raises {
+      mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { caption: "Additional text to accompany the image." })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":url is required in :message", exception.message
+  end
+
+  def test_with_opts
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' }, opts: { client_ref: 'abc123' })
+
+    assert_equal 'abc123', mms.data[:client_ref]
+  end
+end

--- a/test/vonage/messaging/channels/sms_test.rb
+++ b/test/vonage/messaging/channels/sms_test.rb
@@ -1,0 +1,47 @@
+# typed: false
+
+
+class Vonage::Messaging::Channels::SMSTest < Vonage::Test
+  def test_sms_initialize
+    sms = Vonage::Messaging::Channels::SMS.new(message: 'Hello world!')
+
+    assert_kind_of Vonage::Messaging::Channels::SMS, sms
+    assert_equal sms.data, { channel: 'sms', message_type: 'text', text: 'Hello world!' }
+  end
+
+  def test_with_valid_type_specified
+    sms = Vonage::Messaging::Channels::SMS.new(type: 'text', message: 'Hello world!')
+
+    assert_equal 'text', sms.data[:message_type]
+  end
+
+  def test_with_invalid_type_specified
+    exception = assert_raises {
+      Vonage::Messaging::Channels::SMS.new(type: 'image', message: 'Hello world!')
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match "Invalid message type", exception.message
+  end
+
+  def test_with_valid_message_class
+    sms = Vonage::Messaging::Channels::SMS.new(type: 'text', message: 'Hello world!')
+
+    assert_kind_of String, sms.data[:text]
+  end
+
+  def test_with_invalid_message_class
+    exception = assert_raises {
+      Vonage::Messaging::Channels::SMS.new(type: 'text', message: {text: 'Hello world!'} )
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must be a String", exception.message
+  end
+
+  def test_with_opts
+    sms = Vonage::Messaging::Channels::SMS.new(type: 'text', message: 'Hello world!', opts: { client_ref: 'abc123' })
+
+    assert_equal 'abc123', sms.data[:client_ref]
+  end
+end

--- a/test/vonage/messaging/channels/sms_test.rb
+++ b/test/vonage/messaging/channels/sms_test.rb
@@ -13,6 +13,7 @@ class Vonage::Messaging::Channels::SMSTest < Vonage::Test
     sms = Vonage::Messaging::Channels::SMS.new(type: 'text', message: 'Hello world!')
 
     assert_equal 'text', sms.data[:message_type]
+    assert_includes sms.data, :text
   end
 
   def test_with_invalid_type_specified

--- a/test/vonage/messaging/channels/viber_test.rb
+++ b/test/vonage/messaging/channels/viber_test.rb
@@ -1,0 +1,71 @@
+# typed: false
+
+
+class Vonage::Messaging::Channels::ViberTest < Vonage::Test
+  def test_mms_initialize
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!')
+
+    assert_kind_of Vonage::Messaging::Channels::Viber, viber
+    assert_equal viber.data, { channel: ' viber_service', message_type: 'text', text: 'Hello world!' }
+  end
+
+  def test_with_valid_type_text_specified
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!')
+
+    assert_equal 'text', viber.data[:message_type]
+    assert_includes viber.data, :text
+  end
+
+  def test_with_valid_type_image_specified
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_equal 'image', viber.data[:message_type]
+    assert_includes viber.data, :image
+  end
+
+  def test_with_invalid_type_specified
+    exception = assert_raises {
+      viber = Vonage::Messaging::Channels::Viber.new(type: 'audio', message: { url: 'https://example.com/audio.mp3' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match "Invalid message type", exception.message
+  end
+
+  def test_with_valid_message_class
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_kind_of Hash, viber.data[:image]
+  end
+
+  def test_with_invalid_message_class
+    exception = assert_raises {
+      viber = Vonage::Messaging::Channels::Viber.new(type: 'image', message: "https://example.com/image.jpg")
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must be a Hash", exception.message
+  end
+
+  def test_image_without_url
+    exception = assert_raises {
+      viber = Vonage::Messaging::Channels::Viber.new(type: 'image', message: {})
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":url is required in :message", exception.message
+  end
+
+  def test_with_opts_client_ref
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!', opts: { client_ref: 'abc123' })
+
+    assert_equal 'abc123', viber.data[:client_ref]
+  end
+
+  def test_with_opts_viber_service_object
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!', opts: { viber_service: { category: 'transaction', ttl: 600 } })
+
+    assert_equal 'transaction', viber.data[:viber_service][:category]
+    assert_equal 600, viber.data[:viber_service][:ttl]
+  end
+end

--- a/test/vonage/messaging/channels/viber_test.rb
+++ b/test/vonage/messaging/channels/viber_test.rb
@@ -2,7 +2,7 @@
 
 
 class Vonage::Messaging::Channels::ViberTest < Vonage::Test
-  def test_mms_initialize
+  def test_viber_initialize
     viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!')
 
     assert_kind_of Vonage::Messaging::Channels::Viber, viber

--- a/test/vonage/messaging/channels/whats_app_test.rb
+++ b/test/vonage/messaging/channels/whats_app_test.rb
@@ -1,0 +1,130 @@
+# typed: false
+
+
+class Vonage::Messaging::Channels::WhatsAppTest < Vonage::Test
+  def test_messenger_initialize
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'text', message: 'Hello world!')
+
+    assert_kind_of Vonage::Messaging::Channels::WhatsApp, whatsapp
+    assert_equal whatsapp.data, { channel: 'whatsapp', message_type: 'text', text: 'Hello world!' }
+  end
+
+  def test_with_valid_type_text_specified
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'text', message: 'Hello world!')
+
+    assert_equal 'text', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :text
+  end
+
+  def test_with_valid_type_image_specified
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_equal 'image', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :image
+  end
+
+  def test_with_valid_type_audio_specified
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'audio', message: { url: 'https://example.com/audio.mp3' })
+
+    assert_equal 'audio', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :audio
+  end
+
+  def test_with_valid_type_video_specified
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'video', message: { url: 'https://example.com/video.mp4' })
+
+    assert_equal 'video', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :video
+  end
+
+  def test_with_valid_type_file_specified
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'file', message: { url: 'https://example.com/file.pdf' })
+
+    assert_equal 'file', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :file
+  end
+
+  def test_with_invalid_type_specified
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'vcard', message: { url: 'https://example.com/contact.vcf' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match "Invalid message type", exception.message
+  end
+
+  def test_with_valid_message_class
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
+
+    assert_kind_of Hash, whatsapp.data[:image]
+  end
+
+  def test_with_invalid_message_class
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'image', message: "https://example.com/image.jpg")
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must be a Hash", exception.message
+  end
+
+  def test_object_message_without_url
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'image', message: {})
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":url is required in :message", exception.message
+  end
+
+  def test_template_message_without_name
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'template', message: {}, opts: { whatsapp: { policy: 'deterministic', locale: 'en-GB'} })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":name is required in :template", exception.message
+  end
+
+  def test_template_message_without_whatsapp_object
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'template', message: { name: 'verify'})
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":whatsapp is required in :opts", exception.message
+  end
+
+  def test_template_message_without_whatsapp_object_policy
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'template', message: { name: 'verify'}, opts: { whatsapp: { locale: 'en-GB'} })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":policy is required in :whatsapp", exception.message
+  end
+
+  def test_template_message_without_whatsapp_object_locale
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'template', message: { name: 'verify'}, opts: { whatsapp: { policy: 'deterministic'} })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":locale is required in :whatsapp", exception.message
+  end
+
+  def test_custom_message_with_invalid_message_type
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'custom', message: "Hello world!")
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must be a Hash", exception.message
+  end
+
+  def test_with_opts_client_ref
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'text', message: 'Hello world!', opts: { client_ref: 'abc123' })
+
+    assert_equal 'abc123', whatsapp.data[:client_ref]
+  end
+end

--- a/test/vonage/messaging/message_test.rb
+++ b/test/vonage/messaging/message_test.rb
@@ -1,0 +1,33 @@
+# typed: false
+
+class Vonage::Messaging::MessageTest < Vonage::Test
+  def message_class
+    Vonage::Messaging::Message
+  end
+
+  def test_message_with_valid_channel
+    channel_obj_data = message_class.sms(message: "Hello world!")
+    expected_data = {:channel=>"sms", :message_type=>"text", :text=>"Hello world!"}
+
+    assert_equal channel_obj_data, expected_data
+  end
+
+  def test_message_with_valid_channel_and_optional_parameters
+    channel_obj_data = message_class.sms(message: "Hello world!", opts: {client_ref: "abc123"})
+    expected_data = {:channel=>"sms", :message_type=>"text", :text=>"Hello world!", :client_ref=>"abc123"}
+
+    assert_equal channel_obj_data, expected_data
+  end
+
+  def test_message_with_invalid_channel
+    exception = assert_raises { message_class.telepaphy }
+
+    assert_match "Messaging channel must be one of the valid options.", exception.message
+  end
+
+  Vonage::Messaging::Message::CHANNELS.keys.each do |method_name|
+    define_method "test_message_class_#{method_name}_defined_class_method" do
+      assert_respond_to message_class, method_name
+    end
+  end
+end

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -1,0 +1,28 @@
+# typed: false
+require_relative './test'
+
+class Vonage::MessagingTest < Vonage::Test
+  def messaging
+    Vonage::Messaging.new(config)
+  end
+
+  def messaging_uri
+    'https://api.nexmo.com/v1/messages'
+  end
+
+  def test_send_method
+    params = {
+      to: "447700900000",
+      from: "447700900001",
+      channel: "sms",
+      message_type: "text",
+      text: "Hello world!"
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = Vonage::Messaging::Message.sms(message: "Hello world!")
+    
+    assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
+  end
+end


### PR DESCRIPTION
## Reason for this PR

The [Messages API]() is now in General Availability (GA), and so we are adding it to all of the supported Vonage server SDKs.

## What this PR does

- Defines various classes for creating message objects, a general `Message` class and then sub-classes for each channel:
  - `Messenger`
  - `MMS`
  - `SMS`
  - `Viber`
  - `WhatsApp`
- Defines a `Messaging` class inheriting from `Namespace`, which defines a `send` method for sending messages
- Adds a `messaging` method to the `Client` class for creating/ returning `Messaging` objects.
- Adds unit tests to cover the new functionality.
