### PR TITLE
DEVX-5545: Update Voice#create to better support random_from_number

### DIFF
--- a/lib/vonage/voice.rb
+++ b/lib/vonage/voice.rb
@@ -55,6 +55,14 @@ module Vonage
     # @see https://developer.nexmo.com/api/voice#createCall
     #
     def create(params)
+      if params.key?(:from) && params[:random_from_number] == true
+        raise ClientError.new("`from` should not be set if `random_from_number` is `true`")
+      end
+
+      if params && !params.key?(:from)
+        params.merge!(random_from_number: true)
+      end
+
       request('/v1/calls', params: params, type: Post)
     end
 
@@ -101,7 +109,7 @@ module Vonage
       if params && !params.key?(:auto_advance)
         params.merge!(auto_advance: true)
       end
-      
+
       request('/v1/calls', params: params, response_class: ListResponse)
     end
 

--- a/lib/vonage/voice.rb
+++ b/lib/vonage/voice.rb
@@ -19,8 +19,14 @@ module Vonage
     # @option params [required, Array<Hash>] :to
     #   Connect to a Phone (PSTN) number, SIP Endpoint, Websocket, or VBC extension.
     #
-    # @option params [required, Hash] :from
-    #   Connect to a Phone (PSTN) number.
+    # @option params [Hash] :from
+    #   Connect to a Phone (PSTN) number. Should not be set if **:random_from_number** is **true**
+    #   If not set, then **:random_from_number** will automatically be set to **true**
+    #
+    # @option params [Boolean] :random_from_number
+    #   Set to **true** to use random phone number as **from**. The number will be selected from the list
+    #   of the numbers assigned to the current application.
+    #   **random_from_number: true** cannot be used together with **:from**.
     #
     # @option params [Array<String>] :ncco
     #   The Vonage Call Control Object to use for this call.

--- a/test/vonage/voice_test.rb
+++ b/test/vonage/voice_test.rb
@@ -26,6 +26,39 @@ class Vonage::VoiceTest < Vonage::Test
     assert_kind_of Vonage::Response, calls.create(params)
   end
 
+  def test_create_method_raises_error_if_from_set_and_random_from_number_true
+    params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      from: {type: 'phone', number: '14843335555'},
+      random_from_number: true,
+      answer_url: ['https://example.com/answer']
+    }
+
+    exception = assert_raises {
+      calls.create(params)
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match "`from` should not be set if `random_from_number` is `true`", exception.message
+  end
+
+  def test_create_method_sets_random_from_number_to_true_if_from_not_set
+    input_params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      answer_url: ['https://example.com/answer']
+    }
+
+    request_params = {
+      to: [{type: 'phone', number: '14843331234'}],
+      random_from_number: true,
+      answer_url: ['https://example.com/answer']
+    }
+
+    stub_request(:post, calls_uri).with(request(body: request_params)).to_return(response)
+
+    assert_kind_of Vonage::Response, calls.create(input_params)
+  end
+
   def test_list_method
     params = {status: 'completed'}
 


### PR DESCRIPTION
## Reason for this PR

To improve support for usage of a random number from a pool with the Voice API

## What this PR does

- Updates the `Voice#create` method to:
  - Add a conditional check to raise an exception if `from` is set while `random_from_number` is set to `true`
  - Add logic to automatically set  `random_from_number` to `true` if `from` isn't set
- Adds tests to cover the added functionality
- Updates the code comments to:
  - remove the `required` flag from the `from` field
  - Add of the `random_from_number` field

