### PR TITLE
Add Patch HTTP method as option for http_request in JSON.update type sig

### DIFF
--- a/lib/vonage/json.rb
+++ b/lib/vonage/json.rb
@@ -6,7 +6,7 @@ module Vonage
   module JSON
     extend T::Sig
 
-    sig { params(http_request: T.any(Net::HTTP::Put, Net::HTTP::Post, Net::HTTP::Get), params: T::Hash[Symbol, T.untyped]).void }
+    sig { params(http_request: T.any(Net::HTTP::Patch, Net::HTTP::Put, Net::HTTP::Post, Net::HTTP::Get), params: T::Hash[Symbol, T.untyped]).void }
     def self.update(http_request, params)
       http_request['Content-Type'] = 'application/json'
       http_request.body = ::JSON.generate(params)


### PR DESCRIPTION
## Reason for this PR

Adds support for `PATCH` requests to be passed to the `JSON::update` method

## What this PR does

- Updates the Sorbet type signature for the `http_request` parameter of the `JSON::update` method to allow `Net::HTTP::Patch` objects to be passed in.