### PR TITLE
Release 7.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.7.1
+
+* Adds support for `PATCH` requests to be passed to the `JSON::update` method See PR [#230](https://github.com/Vonage/vonage-ruby-sdk/pull/230).
+
 # 7.7.0
 
 * Improves support for the `Voice#create` method to use a random number from a pool. See PR [#225](https://github.com/Vonage/vonage-ruby-sdk/pull/225).

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.7.0'
+  VERSION = '7.7.1'
 end


### PR DESCRIPTION
Changes in this PR:

- Adds support for `PATCH` requests to be passed to the `JSON::update` method: https://github.com/Vonage/vonage-ruby-sdk/pull/230