### PR TITLE
DEVX-6362 fix auto advance for Numbers API

### DIFF
--- a/lib/vonage/namespace.rb
+++ b/lib/vonage/namespace.rb
@@ -109,7 +109,7 @@ module Vonage
       response = make_request!(request, &block)
 
       if auto_advance
-        iterable_request(path, response: response, response_class: response_class, &block)
+        iterable_request(path, response: response, response_class: response_class, params: params, &block)
       else
         return if block
 
@@ -117,7 +117,7 @@ module Vonage
       end
     end
 
-    def iterable_request(path, response: nil, response_class: nil, &block)
+    def iterable_request(path, response: nil, response_class: nil, params: {}, &block)
       json_response = ::JSON.parse(response.body)
       response = parse(response, response_class)
       remainder = remaining_count(json_response)

--- a/test/vonage/numbers_test.rb
+++ b/test/vonage/numbers_test.rb
@@ -45,7 +45,7 @@ class Vonage::NumbersTest < Vonage::Test
 
     stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(numbers_response_paginated_page_1)
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret, index: 2)).to_return(numbers_response_paginated_page_2)
+    stub_request(:get, uri).with(query: params.merge(api_key_and_secret.merge(index: 2))).to_return(numbers_response_paginated_page_2)
 
     response = numbers.search(params.merge(auto_advance: true))
 
@@ -58,7 +58,7 @@ class Vonage::NumbersTest < Vonage::Test
 
     params = {country: country}
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret, index: 2)).to_return(numbers_response_paginated_page_2)
+    stub_request(:get, uri).with(query: params.merge(api_key_and_secret.merge(index: 2))).to_return(numbers_response_paginated_page_2)
 
     response = numbers.search(params.merge(auto_advance: true, index: 2))
 

--- a/test/vonage/numbers_test.rb
+++ b/test/vonage/numbers_test.rb
@@ -38,6 +38,34 @@ class Vonage::NumbersTest < Vonage::Test
     assert_kind_of Vonage::Numbers::ListResponse, numbers.search(params)
   end
 
+  def test_search_method_with_auto_advance
+    uri = 'https://rest.nexmo.com/number/search'
+
+    params = {country: country}
+
+    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(numbers_response_paginated_page_1)
+
+    stub_request(:get, uri).with(query: params.merge(api_key_and_secret, index: 2)).to_return(numbers_response_paginated_page_2)
+
+    response = numbers.search(params.merge(auto_advance: true))
+
+    assert_kind_of Vonage::Numbers::ListResponse, response
+    assert_equal 14, response.numbers.length
+  end
+
+  def test_search_method_with_auto_advance_with_index_offset_by_one_page
+    uri = 'https://rest.nexmo.com/number/search'
+
+    params = {country: country}
+
+    stub_request(:get, uri).with(query: params.merge(api_key_and_secret, index: 2)).to_return(numbers_response_paginated_page_2)
+
+    response = numbers.search(params.merge(auto_advance: true, index: 2))
+
+    assert_kind_of Vonage::Numbers::ListResponse, response
+    assert_equal 4, response.numbers.length
+  end
+
   def test_buy_method
     uri = 'https://rest.nexmo.com/number/buy'
 

--- a/test/vonage/test.rb
+++ b/test/vonage/test.rb
@@ -96,28 +96,204 @@ module Vonage
 
     def voice_response
       {
-        body: '{"_embedded": {"calls":[]}}', 
+        body: '{"_embedded": {"calls":[]}}',
         headers: response_headers
       }
     end
 
     def applications_response
       {
-        body: '{"_embedded": {"applications":[]}}', 
+        body: '{"_embedded": {"applications":[]}}',
         headers: response_headers
       }
     end
 
     def secrets_response
       {
-        body: '{"_embedded": {"secrets":[]}}', 
+        body: '{"_embedded": {"secrets":[]}}',
         headers: response_headers
       }
     end
 
     def numbers_response
       {
-        body: '{"numbers":[]}', 
+        body: '{"numbers":[]}',
+        headers: response_headers
+      }
+    end
+
+    def numbers_response_paginated_page_1
+      {
+        body: '{
+                 "count": 14,
+                 "numbers":[
+                   {
+                    "country": "GB",
+                    "msisdn": "447700900000",
+                    "type": "mobile-lvn",
+                    "cost": "1.25",
+                    "features": [
+                      "VOICE",
+                      "SMS",
+                      "MMS"
+                    ]
+                    },
+                    {
+                     "country": "GB",
+                     "msisdn": "447700900001",
+                     "type": "mobile-lvn",
+                     "cost": "1.25",
+                     "features": [
+                       "VOICE",
+                       "SMS",
+                       "MMS"
+                     ]
+                    },
+                    {
+                     "country": "GB",
+                     "msisdn": "447700900002",
+                     "type": "mobile-lvn",
+                     "cost": "1.25",
+                     "features": [
+                       "VOICE",
+                       "SMS",
+                       "MMS"
+                      ]
+                     },
+                     {
+                      "country": "GB",
+                      "msisdn": "447700900003",
+                      "type": "mobile-lvn",
+                      "cost": "1.25",
+                      "features": [
+                        "VOICE",
+                        "SMS",
+                        "MMS"
+                      ]
+                     },
+                     {
+                      "country": "GB",
+                      "msisdn": "447700900004",
+                      "type": "mobile-lvn",
+                      "cost": "1.25",
+                      "features": [
+                        "VOICE",
+                        "SMS",
+                        "MMS"
+                       ]
+                     },
+                     {
+                      "country": "GB",
+                      "msisdn": "447700900005",
+                      "type": "mobile-lvn",
+                      "cost": "1.25",
+                      "features": [
+                        "VOICE",
+                        "SMS",
+                        "MMS"
+                      ]
+                      },
+                      {
+                       "country": "GB",
+                       "msisdn": "447700900006",
+                       "type": "mobile-lvn",
+                       "cost": "1.25",
+                       "features": [
+                         "VOICE",
+                         "SMS",
+                         "MMS"
+                       ]
+                      },
+                      {
+                       "country": "GB",
+                       "msisdn": "447700900007",
+                       "type": "mobile-lvn",
+                       "cost": "1.25",
+                       "features": [
+                         "VOICE",
+                         "SMS",
+                         "MMS"
+                        ]
+                       },
+                       {
+                        "country": "GB",
+                        "msisdn": "447700900008",
+                        "type": "mobile-lvn",
+                        "cost": "1.25",
+                        "features": [
+                          "VOICE",
+                          "SMS",
+                          "MMS"
+                        ]
+                       },
+                       {
+                        "country": "GB",
+                        "msisdn": "447700900009",
+                        "type": "mobile-lvn",
+                        "cost": "1.25",
+                        "features": [
+                          "VOICE",
+                          "SMS",
+                          "MMS"
+                         ]
+                       }
+                      ]
+                    }',
+        headers: response_headers
+      }
+    end
+
+    def numbers_response_paginated_page_2
+      {
+        body: '{
+                 "count": 14,
+                 "numbers":[
+                      {
+                       "country": "GB",
+                       "msisdn": "447700900010",
+                       "type": "mobile-lvn",
+                       "cost": "1.25",
+                       "features": [
+                         "VOICE",
+                         "SMS",
+                         "MMS"
+                       ]
+                      },
+                      {
+                       "country": "GB",
+                       "msisdn": "447700900011",
+                       "type": "mobile-lvn",
+                       "cost": "1.25",
+                       "features": [
+                         "VOICE",
+                         "SMS",
+                         "MMS"
+                        ]
+                       },
+                       {
+                        "country": "GB",
+                        "msisdn": "447700900012",
+                        "type": "mobile-lvn",
+                        "cost": "1.25",
+                        "features": [
+                          "VOICE",
+                          "SMS",
+                          "MMS"
+                        ]
+                       },
+                       {
+                        "country": "GB",
+                        "msisdn": "447700900013",
+                        "type": "mobile-lvn",
+                        "cost": "1.25",
+                        "features": [
+                          "VOICE",
+                          "SMS",
+                          "MMS"
+                         ]
+                       }
+                      ]
+                    }',
         headers: response_headers
       }
     end


### PR DESCRIPTION
## Reason for this PR

To fix a bug when setting the `auto_advance` parameter to `true` when making requests with the `Numbers` class `list` and `search` methods.

The cause of this bug was that auto advance relied on the `Namespace#iterable_request`, the implementation of which didn't work for the Numbers API because responses from that API don't include a `record_index` value.

## What this PR does

- Implements a specific version of `iterable_request` in the `Numbers` class which over-rides the version in `Namespace`.