### PR TITLE
Add Patch HTTP method as option in Logger.log_request_info type sig

### DIFF
--- a/lib/vonage/logger.rb
+++ b/lib/vonage/logger.rb
@@ -18,7 +18,7 @@ module Vonage
       def_delegator :@logger, name, name
     end
 
-    sig { params(request: T.any(Net::HTTP::Post, Net::HTTP::Get, Net::HTTP::Delete, Net::HTTP::Put)).void }
+    sig { params(request: T.any(Net::HTTP::Post, Net::HTTP::Get, Net::HTTP::Delete, Net::HTTP::Put, Net::HTTP::Patch)).void }
     def log_request_info(request)
       @logger = T.let(@logger, T.nilable(T.any(::Logger, Vonage::Logger)))
 


### PR DESCRIPTION
## Reason for this PR

Adds support for `PATCH` requests to be passed to the `Logger#log_request_info` method

## What this PR does

- Updates the Sorbet type signature for the `request` parameter of the `Logger#log_request_info` method to allow `Net::HTTP::Patch` objects to be passed in.