### PR TITLE
DEVX-6439: Update Messages API Template Message class

### DIFF
--- a/lib/vonage/messaging/channels/whats_app.rb
+++ b/lib/vonage/messaging/channels/whats_app.rb
@@ -34,7 +34,6 @@ module Vonage
         raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
         raise Vonage::ClientError.new(":name is required in :template") unless message[:name]
         raise Vonage::ClientError.new(":whatsapp is required in :opts") unless opts[:whatsapp]
-        raise Vonage::ClientError.new(":policy is required in :whatsapp") unless opts[:whatsapp][:policy]
         raise Vonage::ClientError.new(":locale is required in :whatsapp") unless opts[:whatsapp][:locale]
       when 'custom'
         raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash

--- a/test/vonage/messaging/channels/whats_app_test.rb
+++ b/test/vonage/messaging/channels/whats_app_test.rb
@@ -95,15 +95,6 @@ class Vonage::Messaging::Channels::WhatsAppTest < Vonage::Test
     assert_match ":whatsapp is required in :opts", exception.message
   end
 
-  def test_template_message_without_whatsapp_object_policy
-    exception = assert_raises {
-      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'template', message: { name: 'verify'}, opts: { whatsapp: { locale: 'en-GB'} })
-    }
-
-    assert_instance_of Vonage::ClientError, exception
-    assert_match ":policy is required in :whatsapp", exception.message
-  end
-
   def test_template_message_without_whatsapp_object_locale
     exception = assert_raises {
       whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'template', message: { name: 'verify'}, opts: { whatsapp: { policy: 'deterministic'} })


### PR DESCRIPTION
## Reason for this PR

Due to an error in the Messages API spec for the WhatsApp Template type message, the SDK tested for the presence of the `policy` property in the `whatsapp` object of the WhatsApp Template message type. The spec incorrectly had this property as required, but it is in fact optional. See [this JIRA ticket](https://jira.vonage.com/browse/DEVX-6412) for  additional context

This PR updated the Ruby SDK to remove a check that validates for the presence of that property.

## What this PR does

- Updates the `Messaging::Channels::WhatsApp#verify_message` method to remove a validation check for the required presence of `opts[:whatsapp][:policy]`
- Removes the test associated with this validation logic from `Messaging::Channels::WhatsAppTest`