### PR TITLE
DEVX-5865: Automated Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,25 @@ on:
   release:
     types: [published]
 jobs:
-  add-changelog:
-    name: Add Changelog
+  build:
     runs-on: ubuntu-latest
     steps:
-    - name: Add Changelog
-      uses: nexmo/github-actions/nexmo-changelog@main
-      env:
-        CHANGELOG_AUTH_TOKEN: ${{ secrets.CHANGELOG_AUTH_TOKEN }}
-        CHANGELOG_CATEGORY: Server SDK
-        CHANGELOG_RELEASE_TITLE: vonage-ruby
-        CHANGELOG_SUBCATEGORY: ruby
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.target_commitish }} 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+      - run: bundle install
+      - name: Set Credentials
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+      - name: Publish Gem
+        run: rake publish_gem

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ Gemfile.lock
 coverage
 doc
 sorbet/rbi/hidden-definitions/errors.txt
+*.gem
+/pkg/
+.rake_tasks~

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require "bundler/gem_tasks"
 require 'yard'
 
 task :default => :test
@@ -9,3 +10,19 @@ Rake::TestTask.new(:test) do |t|
 end
 
 YARD::Rake::YardocTask.new
+
+desc "Build gem"
+task :build_gem do
+  `rake build`
+end
+
+desc "Publish gem"
+task publish_gem: [:build_gem] do
+  `gem push pkg/*.gem`
+  Rake::Task[:empty_pkg].invoke
+end
+
+desc "Empty pkg directory"
+task :empty_pkg do
+  `rm -rf pkg/*`
+end


### PR DESCRIPTION
## Reason for this PR

To automated the process for publishing the Ruby SDK to RubyGems when a new release is created.

## What this PR does

- Adds Rake tasks for creating and publishing the SDK to RubyGems
- Updates the GitHub workflow defined in `release.yml` to:
  - Remove the update of the Nexmo Changelog (which is no longer used)
  - Run the Rake tasks to publish to RubyGems