### PR TITLE
DEVX-6418: Adding Voice NCCO Pay action

### DIFF
--- a/lib/vonage/voice/actions/pay.rb
+++ b/lib/vonage/voice/actions/pay.rb
@@ -1,0 +1,107 @@
+# typed: true
+# frozen_string_literal: true
+module Vonage
+  class Voice::Actions::Pay
+    attr_accessor :amount, :currency, :eventUrl, :prompts, :voice
+
+    def initialize(attributes= {})
+      @amount = attributes.fetch(:amount)
+      @currency = attributes.fetch(:currency, nil)
+      @eventUrl = attributes.fetch(:eventUrl, nil)
+      @prompts = attributes.fetch(:prompts, nil)
+      @voice = attributes.fetch(:voice, nil)
+
+      after_initialize!
+    end
+
+    def action
+      create_pay!(self)
+    end
+
+    def create_pay!(builder)
+      ncco = [
+        {
+          action: 'pay',
+          amount: builder.amount
+        }
+      ]
+
+      ncco[0].merge!(currency: builder.currency) if builder.currency
+      ncco[0].merge!(eventUrl: builder.eventUrl) if builder.eventUrl
+      ncco[0].merge!(prompts: builder.prompts) if builder.prompts
+      ncco[0].merge!(voice: builder.voice) if builder.voice
+
+      ncco
+    end
+
+    private
+
+    def after_initialize!
+      verify_amount
+
+      if self.eventUrl
+        verify_event_url
+      end
+
+      if self.prompts
+        verify_prompts
+      end
+
+      if self.voice
+        verify_voice
+      end
+    end
+
+    def verify_amount
+      verify_amount_class
+      verify_amount_value
+    end
+
+    def verify_event_url
+      raise ClientError.new("Expected 'eventUrl' parameter to be an Array containing a single string item") unless self.eventUrl.is_a?(Array)
+
+      uri = URI.parse(self.eventUrl[0])
+
+      raise ClientError.new("Invalid 'eventUrl' value, must be a valid URL") unless uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)
+    end
+
+    def verify_prompts
+      verify_prompts_structure
+      verify_prompts_values
+    end
+
+    def verify_voice
+      verify_voice_structure
+      verify_voice_style if self.voice[:style]
+    end
+
+    def verify_amount_class
+      raise ClientError.new("Invalid 'amount' value, must be a float") unless self.amount.is_a?(Float)
+    end
+
+    def verify_amount_value
+      raise ClientError.new("Invalid 'amount' value, must be greater than 0") unless self.amount > 0
+    end
+
+    def verify_prompts_structure
+      raise ClientError.new("Invalid 'prompt', must be an array of at least one hash") unless self.prompts.is_a?(Array) && !self.prompts.empty? && self.prompts.all?(Hash)
+    end
+
+    def verify_prompts_values
+      self.prompts.each do |prompt|
+        prompt_keys = prompt.keys
+        [:type, :text, :errors].each do |key|
+          raise ClientError.new("Invalid 'prompt', '#{key}' is required") unless prompt_keys.include?(key)
+        end
+      end
+    end
+
+    def verify_voice_structure
+      raise ClientError.new("Expected 'voice' value to be a Hash") unless self.voice.is_a?(Hash)
+    end
+
+    def verify_voice_style
+      raise ClientError.new("Expected 'style' value to be an Integer") unless self.voice[:style].is_a?(Integer)
+    end
+  end
+end

--- a/test/vonage/voice/actions/pay_test.rb
+++ b/test/vonage/voice/actions/pay_test.rb
@@ -1,0 +1,155 @@
+# typed: false
+
+class Vonage::Voice::Actions::PayTest < Vonage::Test
+  def test_pay_initialize
+    pay = Vonage::Voice::Actions::Pay.new(amount: 9.99)
+
+    assert_kind_of Vonage::Voice::Actions::Pay, pay
+    assert_equal 9.99, pay.amount
+  end
+
+  def test_create_pay
+    expected = [{ action: 'pay', amount: 9.99 }]
+    pay = Vonage::Voice::Actions::Pay.new(amount: 9.99)
+
+    assert_equal expected, pay.create_pay!(pay)
+  end
+
+  def test_create_pay_with_optional_params
+    expected = [{ action: 'pay', amount: 9.99, currency: "eur" }]
+    pay = Vonage::Voice::Actions::Pay.new(amount: 9.99, currency: "eur")
+
+    assert_equal expected, pay.create_pay!(pay)
+  end
+
+  def test_create_pay_with_prompts_voice_settings
+    expected = [{ action: 'pay', amount: 9.99, voice: { language: 'en-GB', style: 9 } }]
+    pay = Vonage::Voice::Actions::Pay.new(amount: 9.99, voice: { language: 'en-GB', style: 9 })
+
+    assert_equal expected, pay.create_pay!(pay)
+  end
+
+  def test_create_pay_with_language_no_style
+    expected = [{ action: 'pay', amount: 9.99, voice: { language: 'en-GB' } }]
+    pay = Vonage::Voice::Actions::Pay.new(amount: 9.99, voice: { language: 'en-GB' })
+
+    assert_equal expected, pay.create_pay!(pay)
+  end
+
+  def test_create_pay_with_style_no_language
+    expected = [{ action: 'pay', amount: 9.99, voice: { style: 9 } }]
+    pay = Vonage::Voice::Actions::Pay.new(amount: 9.99, voice: { style: 9 })
+
+    assert_equal expected, pay.create_pay!(pay)
+  end
+
+  def test_create_pay_with_prompts_text_settings
+    expected = [{
+      action: 'pay',
+      amount: 9.99,
+      prompts: [{
+        type: 'ExpirationDate',
+        text: 'Please enter expiration date',
+        errors: {
+          InvalidExpirationDate: {
+            text: 'Invalid expiration date. Please try again'
+          }
+        }
+      }]
+    }]
+    pay = Vonage::Voice::Actions::Pay.new(
+      amount: 9.99,
+      prompts: [{
+        type: 'ExpirationDate',
+        text: 'Please enter expiration date',
+        errors: {
+          InvalidExpirationDate: {
+            text: 'Invalid expiration date. Please try again'
+          }
+        }
+      }]
+    )
+
+    assert_equal expected, pay.create_pay!(pay)
+  end
+
+  def test_pay_with_invalid_amount_value_zero
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(amount: 0.00) }
+
+    assert_match "Invalid 'amount' value, must be greater than 0", exception.message
+  end
+
+  def test_pay_with_invalid_amount_value_non_decimal
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(amount: 1) }
+
+    assert_match "Invalid 'amount' value, must be a float", exception.message
+  end
+
+  def test_pay_with_invalid_event_url_structure
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(amount: 9.99, eventUrl: "https://example.com/pay") }
+
+    assert_match "Expected 'eventUrl' parameter to be an Array containing a single string item", exception.message
+  end
+
+  def test_pay_with_invalid_event_url_value
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(amount: 9.99, eventUrl: ["example.com/pay"]) }
+
+    assert_match "Invalid 'eventUrl' value, must be a valid URL", exception.message
+  end
+
+  def test_create_pay_with_invalid_voice_structure
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(amount: 9.99, voice: 'en-GB') }
+
+    assert_match "Expected 'voice' value to be a Hash", exception.message
+  end
+
+  def test_create_pay_with_invalid_style_value
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(amount: 9.99, voice: { language: 'en-GB', style: 'baritone' }) }
+
+    assert_match "Expected 'style' value to be an Integer", exception.message
+  end
+
+  def test_create_pay_with_prompts_type_missing
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(
+      amount: 9.99,
+      prompts: [{
+        text: 'Please enter expiration date',
+        errors: {
+          InvalidExpirationDate: {
+            text: 'Invalid expiration date. Please try again'
+          }
+        }
+      }]
+    )}
+
+    assert_match "Invalid 'prompt', 'type' is required", exception.message
+  end
+
+  def test_create_pay_with_prompts_text_missing
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(
+      amount: 9.99,
+      prompts: [{
+        type: 'ExpirationDate',
+        errors: {
+          InvalidExpirationDate: {
+            text: 'Invalid expiration date. Please try again'
+          }
+        }
+      }]
+    )}
+
+    assert_match "Invalid 'prompt', 'text' is required", exception.message
+  end
+
+  def test_create_pay_with_prompts_errors_missing
+    exception = assert_raises { Vonage::Voice::Actions::Pay.new(
+      amount: 9.99,
+      prompts: [{
+        type: 'ExpirationDate',
+        text: 'Please enter expiration date'
+      }]
+    )}
+
+    assert_match "Invalid 'prompt', 'errors' is required", exception.message
+  end
+end


### PR DESCRIPTION
## Reason for this PR

The [NCCO reference](https://developer.vonage.com/voice/voice-api/ncco-reference#pay) has added an action for `Pay`, which therefore needed to be implemented in the Ruby SDK.

## What this PR does

- Defines an NCCO `Pay` action under `Voice::Actions`
- Adds tests for this new action