### PR TITLE
DEVX-6463: Fix client instantiation with custom token

### DIFF
--- a/lib/vonage/config.rb
+++ b/lib/vonage/config.rb
@@ -191,7 +191,7 @@ module Vonage
     #
     sig { returns(T.nilable(String)) }
     def token
-      @token = T.let(nil, T.nilable(String))
+      @token = T.let(@token, T.nilable(String))
       @token || JWT.generate({application_id: application_id}, T.must(private_key))
     end
 

--- a/test/vonage/config_test.rb
+++ b/test/vonage/config_test.rb
@@ -61,4 +61,12 @@ class Vonage::ConfigTest < Vonage::Test
 
     assert_includes exception.message, 'No signature_secret provided.'
   end
+
+  def test_custom_token_can_be_set_and_returned
+    token = Vonage::JWT.generate(application_id: application_id, private_key: private_key, nbf: 1483315200, ttl: 800)
+
+    config = Vonage::Config.new.merge(token: token)
+
+    assert_equal token, config.token
+  end
 end


### PR DESCRIPTION
## Reason for this PR

Fixes a bug preventing users of the SDK from setting their own JWT rather than using one generated by the SDK. See https://github.com/Vonage/vonage-ruby-sdk/issues/240

## What this PR does

- Updates the `Config#token` method so that it correctly returns a token that has been set when a `Config` object is created (i.e. by `Namespace#build_request` method)
- Adds a test to ensure that the set token is the one that is returned by `Config#token`