### PR TITLE
DEVX-6472: Adding more Verify tests for Blacklist error response

### DIFF
--- a/test/vonage/verify_test.rb
+++ b/test/vonage/verify_test.rb
@@ -62,6 +62,51 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
+  def test_blacklist_error_for_verify_with_network
+    uri = 'https://api.nexmo.com/verify/json'
+
+    params = {number: msisdn, brand: 'ExampleApp'}
+
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network)
+
+    error = assert_raises Vonage::ServiceError do
+      verify.request(params)
+    end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
+  end
+
+  def test_blacklist_error_for_verify_with_request_id
+    uri = 'https://api.nexmo.com/verify/json'
+
+    params = {number: msisdn, brand: 'ExampleApp'}
+
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_request_id)
+
+    error = assert_raises Vonage::ServiceError do
+      verify.request(params)
+    end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
+  end
+
+  def test_blacklist_error_for_verify_with_network_and_request_id
+    uri = 'https://api.nexmo.com/verify/json'
+
+    params = {number: msisdn, brand: 'ExampleApp'}
+
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network_and_request_id)
+
+    error = assert_raises Vonage::ServiceError do
+      verify.request(params)
+    end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
+  end
+
   def test_check_method
     uri = 'https://api.nexmo.com/verify/check/json'
 
@@ -164,45 +209,45 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_with_network
-    uri = 'https://api.nexmo.com/verify/json'
+  def test_blacklist_error_for_psd2_with_network
+    uri = 'https://api.nexmo.com/verify/psd2/json'
 
-    params = {number: msisdn, brand: 'ExampleApp'}
+    params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
     stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network)
 
     error = assert_raises Vonage::ServiceError do
-      verify.request(params)
+      verify.psd2(params)
     end
 
     assert_kind_of Vonage::Error, error
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_with_request_id
-    uri = 'https://api.nexmo.com/verify/json'
+  def test_blacklist_error_for_psd2_with_request_id
+    uri = 'https://api.nexmo.com/verify/psd2/json'
 
-    params = {number: msisdn, brand: 'ExampleApp'}
+    params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
     stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_request_id)
 
     error = assert_raises Vonage::ServiceError do
-      verify.request(params)
+      verify.psd2(params)
     end
 
     assert_kind_of Vonage::Error, error
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_with_network_and_request_id
-    uri = 'https://api.nexmo.com/verify/json'
+  def test_blacklist_error_for_psd2_with_network_and_request_id
+    uri = 'https://api.nexmo.com/verify/psd2/json'
 
-    params = {number: msisdn, brand: 'ExampleApp'}
+    params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
     stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network_and_request_id)
 
     error = assert_raises Vonage::ServiceError do
-      verify.request(params)
+      verify.psd2(params)
     end
 
     assert_kind_of Vonage::Error, error

--- a/test/vonage/verify_test.rb
+++ b/test/vonage/verify_test.rb
@@ -24,24 +24,24 @@ class Vonage::VerifyTest < Vonage::Test
     }
   end
 
-  def error_response_blacklist_with_network
+  def error_response_blocklist_with_network
     {
       headers: response_headers,
-      body: '{"status":"7","error_text":"The number you are trying to verify is blacklisted for verification","network":"25503"}'
+      body: '{"status":"7","error_text":"The number you are trying to verify is blocklisted for verification","network":"25503"}'
     }
   end
 
-  def error_response_blacklist_with_request_id
+  def error_response_blocklist_with_request_id
     {
       headers: response_headers,
-      body: '{"request_id":"8g88g88eg8g8gg9g90","status":"7","error_text":"The number you are trying to verify is blacklisted for verification"}'
+      body: '{"request_id":"8g88g88eg8g8gg9g90","status":"7","error_text":"The number you are trying to verify is blocklisted for verification"}'
     }
   end
 
-  def error_response_blacklist_with_network_and_request_id
+  def error_response_blocklist_with_network_and_request_id
     {
       headers: response_headers,
-      body: '{"request_id":"8g88g88eg8g8gg9g90","status":"7","error_text":"The number you are trying to verify is blacklisted for verification","network":"25503"}'
+      body: '{"request_id":"8g88g88eg8g8gg9g90","status":"7","error_text":"The number you are trying to verify is blocklisted for verification","network":"25503"}'
     }
   end
 
@@ -62,12 +62,12 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_for_verify_with_network
+  def test_blocklist_error_for_verify_with_network
     uri = 'https://api.nexmo.com/verify/json'
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network)
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network)
 
     error = assert_raises Vonage::ServiceError do
       verify.request(params)
@@ -77,12 +77,12 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_for_verify_with_request_id
+  def test_blocklist_error_for_verify_with_request_id
     uri = 'https://api.nexmo.com/verify/json'
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_request_id)
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.request(params)
@@ -92,12 +92,12 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_for_verify_with_network_and_request_id
+  def test_blocklist_error_for_verify_with_network_and_request_id
     uri = 'https://api.nexmo.com/verify/json'
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network_and_request_id)
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network_and_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.request(params)
@@ -209,12 +209,12 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_for_psd2_with_network
+  def test_blocklist_error_for_psd2_with_network
     uri = 'https://api.nexmo.com/verify/psd2/json'
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network)
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network)
 
     error = assert_raises Vonage::ServiceError do
       verify.psd2(params)
@@ -224,12 +224,12 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_for_psd2_with_request_id
+  def test_blocklist_error_for_psd2_with_request_id
     uri = 'https://api.nexmo.com/verify/psd2/json'
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_request_id)
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.psd2(params)
@@ -239,12 +239,12 @@ class Vonage::VerifyTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
-  def test_blacklist_error_for_psd2_with_network_and_request_id
+  def test_blocklist_error_for_psd2_with_network_and_request_id
     uri = 'https://api.nexmo.com/verify/psd2/json'
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blacklist_with_network_and_request_id)
+    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network_and_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.psd2(params)


### PR DESCRIPTION
## Reason for this PR

The Verify API has a new possible error response for the `https://api.nexmo.com/verify/json`, which can return a response with and without certain properties in the response body. This PR is to ensure that the existing implementation of Verify in the Ruby SDK handles the various permutations of this response correctly. See [this JIRA ticket](https://jira.vonage.com/browse/DEVX-6466) for additional context. 

## What this PR does

- Following the addition of the tests for the `verify` endpoint already added in #241, this PR adds three more tests to `verify_test.rb` for the for `psd2` endpoint:
  - One to check an blacklist error response for `psd2` endpoint with `network` but not `request_id`
  - One to check an blacklist error response for `psd2` endpoinwith `request_id` but not `network`
  - One to check an blacklist error response for `psd2` endpoinwith `request_id` and `network`