### PR TITLE
Release 7.8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 7.8.2
+
+* Updates the GSM::CHARACTERS constant to remove `ç` and instead add `Ç`. Fixes [#256](https://github.com/Vonage/vonage-ruby-sdk/issues/255)
+* Updates code comments for `SMS#send` method to remove properties for unsupported message types `vCal`, `vCard`, and `wappush`
+* Updates namespacing for referencing `SecurityUtils#secure_compare` method due to change in `ruby-jwt ` gem dependency. 
+
 # 7.8.1
 
 * Changes JWT library dependency from `nexmo-jwt-ruby` to `conage-jwt-ruby`. See PR [#251](https://github.com/Vonage/vonage-ruby-sdk/pull/251)

--- a/lib/vonage/gsm7.rb
+++ b/lib/vonage/gsm7.rb
@@ -4,7 +4,7 @@ module Vonage
   module GSM7
     extend T::Sig
     
-    CHARACTERS = "\n\f\r !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~ ¡£¤¥§¿ÄÅÆÉÑÖØÜßàäåæçèéìñòöøùüΓΔΘΛΞΠΣΦΨΩ€"
+    CHARACTERS = "\n\f\r !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~ ¡£¤¥§¿ÄÅÆÇÉÑÖØÜßàäåæèéìñòöøùüΓΔΘΛΞΠΣΦΨΩ€"
 
     REGEXP = /\A[#{Regexp.escape(CHARACTERS)}]*\z/
 

--- a/lib/vonage/signature.rb
+++ b/lib/vonage/signature.rb
@@ -32,7 +32,7 @@ module Vonage
 
       signature = params.delete('sig')
 
-      ::JWT::SecurityUtils.secure_compare(signature, digest(params, signature_method))
+      secure_compare(signature, digest(params, signature_method))
     end
 
     private
@@ -48,6 +48,17 @@ module Vonage
       else
         raise ArgumentError, "Unknown signature algorithm: #{signature_method}. Expected: md5hash, md5, sha1, sha256, or sha512."
       end
+    end
+
+    def secure_compare(left, right)
+      left_bytesize = left.bytesize
+
+      return false unless left_bytesize == right.bytesize
+
+      unpacked_left = left.unpack "C#{left_bytesize}"
+      result = 0
+      right.each_byte { |byte| result |= byte ^ unpacked_left.shift }
+      result.zero?
     end
   end
 end

--- a/lib/vonage/signature.rb
+++ b/lib/vonage/signature.rb
@@ -32,7 +32,7 @@ module Vonage
 
       signature = params.delete('sig')
 
-      secure_compare(signature, digest(params, signature_method))
+      ::JWT::Algos::Hmac::SecurityUtils.secure_compare(signature, digest(params, signature_method))
     end
 
     private
@@ -48,17 +48,6 @@ module Vonage
       else
         raise ArgumentError, "Unknown signature algorithm: #{signature_method}. Expected: md5hash, md5, sha1, sha256, or sha512."
       end
-    end
-
-    def secure_compare(left, right)
-      left_bytesize = left.bytesize
-
-      return false unless left_bytesize == right.bytesize
-
-      unpacked_left = left.unpack "C#{left_bytesize}"
-      result = 0
-      right.each_byte { |byte| result |= byte ^ unpacked_left.shift }
-      result.zero?
     end
   end
 end

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -47,14 +47,6 @@ module Vonage
     # @option params [String] :type
     #   The format of the message body.
     #
-    # @option params [String] :vcard
-    #   A business card in [vCard format](https://en.wikipedia.org/wiki/VCard).
-    #   Depends on **:type** option having the value `vcard`.
-    #
-    # @option params [String] :vcal
-    #   A calendar event in [vCal format](https://en.wikipedia.org/wiki/VCal).
-    #   Depends on **:type** option having the value `vcal`.
-    #
     # @option params [String] :body
     #   Hex encoded binary data.
     #   Depends on **:type** option having the value `binary`.
@@ -66,18 +58,6 @@ module Vonage
     # @option params [Integer] :protocol_id
     #   The value of the [protocol identifier](https://en.wikipedia.org/wiki/GSM_03.40#Protocol_Identifier) to use.
     #   Ensure that the value is aligned with **:udh**.
-    #
-    # @option params [String] :title
-    #   The title for a wappush SMS.
-    #   Depends on **:type** option having the value `wappush`.
-    #
-    # @option params [String] :url
-    #   The URL of your website.
-    #   Depends on **:type** option having the value `wappush`.
-    #
-    # @option params [String] :validity
-    #   The availability for an SMS in milliseconds.
-    #   Depends on **:type** option having the value `wappush`.
     #
     # @option params [String] :client_ref
     #   You can optionally include your own reference of up to 40 characters.

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.8.1'
+  VERSION = '7.8.2'
 end


### PR DESCRIPTION
* Updates the GSM::CHARACTERS constant to remove `ç` and instead add `Ç`. Fixes [#256](https://github.com/Vonage/vonage-ruby-sdk/issues/255)
* Updates code comments for `SMS#send` method to remove properties for unsupported message types `vCal`, `vCard`, and `wappush`
* Updates namespacing for referencing `SecurityUtils#secure_compare` method due to change in `ruby-jwt ` gem dependency. 