### PR TITLE
DEVX-7131: Updating Numbers implementation to use Basic auth

### DIFF
--- a/lib/vonage/numbers.rb
+++ b/lib/vonage/numbers.rb
@@ -5,6 +5,8 @@ module Vonage
   class Numbers < Namespace
     include Keys
 
+    self.authentication = Basic
+
     self.host = :rest_host
 
     # Retrieve all the inbound numbers associated with your Vonage account.
@@ -52,7 +54,7 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#getOwnedNumbers
     #
     def list(params = nil)
-      request('/account/numbers', params: params, response_class: ListResponse)
+      request("/account/numbers", params: params, response_class: ListResponse)
     end
 
     # Retrieve inbound numbers that are available for the specified country.
@@ -100,7 +102,7 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#getAvailableNumbers
     #
     def search(params)
-      request('/number/search', params: params, response_class: ListResponse)
+      request("/number/search", params: params, response_class: ListResponse)
     end
 
     # Request to purchase a specific inbound number.
@@ -125,7 +127,12 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#buyANumber
     #
     def buy(params)
-      request('/number/buy', params: params, type: Post, response_class: Response)
+      request(
+        "/number/buy",
+        params: params,
+        type: Post,
+        response_class: Response
+      )
     end
 
     # Cancel your subscription for a specific inbound number.
@@ -150,7 +157,12 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#cancelANumber
     #
     def cancel(params)
-      request('/number/cancel', params: params, type: Post, response_class: Response)
+      request(
+        "/number/cancel",
+        params: params,
+        type: Post,
+        response_class: Response
+      )
     end
 
     # Change the behaviour of a number that you own.
@@ -198,14 +210,25 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#updateANumber
     #
     def update(params)
-      request('/number/update', params: camelcase(params), type: Post, response_class: Response)
+      request(
+        "/number/update",
+        params: camelcase(params),
+        type: Post,
+        response_class: Response
+      )
     end
 
     private
 
     # A specific implementation of iterable_request for Numbers, because the Numbers API
     # handles pagination differently to other Vonage APIs
-    def iterable_request(path, response: nil, response_class: nil, params: {}, &block)
+    def iterable_request(
+      path,
+      response: nil,
+      response_class: nil,
+      params: {},
+      &block
+    )
       response = parse(response, response_class)
       params[:index] = 1 unless params.has_key?(:index)
       size = params.fetch(:size, 10)

--- a/test/vonage/numbers_test.rb
+++ b/test/vonage/numbers_test.rb
@@ -1,5 +1,5 @@
 # typed: false
-require_relative './test'
+require_relative "./test"
 
 class Vonage::NumbersTest < Vonage::Test
   def numbers
@@ -7,45 +7,49 @@ class Vonage::NumbersTest < Vonage::Test
   end
 
   def test_list_method
-    uri = 'https://rest.nexmo.com/account/numbers'
+    uri = "https://rest.nexmo.com/account/numbers"
 
-    params = {size: 25, pattern: '33'}
+    params = { size: 25, pattern: "33" }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(numbers_response)
+    stub_request(:get, uri).with(query: params).to_return(numbers_response)
 
     response = numbers.list(params)
 
-    response.each{|resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
+    response.each { |resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
   end
 
   def test_list_method_without_args
-    uri = 'https://rest.nexmo.com/account/numbers'
+    uri = "https://rest.nexmo.com/account/numbers"
 
-    stub_request(:get, uri).with(query: api_key_and_secret).to_return(numbers_response)
+    stub_request(:get, uri).to_return(numbers_response)
 
     response = numbers.list
 
-    response.each{|resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
+    response.each { |resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
   end
 
   def test_search_method
-    uri = 'https://rest.nexmo.com/number/search'
+    uri = "https://rest.nexmo.com/number/search"
 
-    params = {size: 25, country: country}
+    params = { size: 25, country: country }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:get, uri).with(query: params).to_return(response)
 
     assert_kind_of Vonage::Numbers::ListResponse, numbers.search(params)
   end
 
   def test_search_method_with_auto_advance
-    uri = 'https://rest.nexmo.com/number/search'
+    uri = "https://rest.nexmo.com/number/search"
 
-    params = {country: country}
+    params = { country: country }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(numbers_response_paginated_page_1)
+    stub_request(:get, uri).with(query: params).to_return(
+      numbers_response_paginated_page_1
+    )
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret.merge(index: 2))).to_return(numbers_response_paginated_page_2)
+    stub_request(:get, uri).with(query: params.merge(index: 2)).to_return(
+      numbers_response_paginated_page_2
+    )
 
     response = numbers.search(params.merge(auto_advance: true))
 
@@ -54,11 +58,13 @@ class Vonage::NumbersTest < Vonage::Test
   end
 
   def test_search_method_with_auto_advance_with_index_offset_by_one_page
-    uri = 'https://rest.nexmo.com/number/search'
+    uri = "https://rest.nexmo.com/number/search"
 
-    params = {country: country}
+    params = { country: country }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret.merge(index: 2))).to_return(numbers_response_paginated_page_2)
+    stub_request(:get, uri).with(query: params.merge(index: 2)).to_return(
+      numbers_response_paginated_page_2
+    )
 
     response = numbers.search(params.merge(auto_advance: true, index: 2))
 
@@ -67,34 +73,49 @@ class Vonage::NumbersTest < Vonage::Test
   end
 
   def test_buy_method
-    uri = 'https://rest.nexmo.com/number/buy'
+    uri = "https://rest.nexmo.com/number/buy"
 
-    params = {country: country, msisdn: msisdn}
+    params = { country: country, msisdn: msisdn }
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(headers: headers, body: params).to_return(
+      response
+    )
 
     assert_kind_of Vonage::Numbers::Response, numbers.buy(params)
   end
 
   def test_cancel_method
-    uri = 'https://rest.nexmo.com/number/cancel'
+    uri = "https://rest.nexmo.com/number/cancel"
 
-    params = {country: country, msisdn: msisdn}
+    params = { country: country, msisdn: msisdn }
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(headers: headers, body: params).to_return(
+      response
+    )
 
     assert_kind_of Vonage::Numbers::Response, numbers.cancel(params)
   end
 
   def test_update_method
-    uri = 'https://rest.nexmo.com/number/update'
+    uri = "https://rest.nexmo.com/number/update"
 
-    mo_http_url = 'https://example.com/callback'
+    mo_http_url = "https://example.com/callback"
 
-    params = {'country' => country, 'msisdn' => msisdn, 'moHttpUrl' => mo_http_url}
+    params = {
+      "country" => country,
+      "msisdn" => msisdn,
+      "moHttpUrl" => mo_http_url
+    }
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(headers: headers, body: params).to_return(
+      response
+    )
 
-    assert_kind_of Vonage::Numbers::Response, numbers.update(country: country, msisdn: msisdn, mo_http_url: mo_http_url)
+    assert_kind_of Vonage::Numbers::Response,
+                   numbers.update(
+                     country: country,
+                     msisdn: msisdn,
+                     mo_http_url: mo_http_url
+                   )
   end
 end


### PR DESCRIPTION
This PR does the following:

- Updates the `authentication` method for `Numbers` to `Basic`
- Updates all tests in `NumbersTest` in line with usage of `Basic` auth