### PR TITLE
Release 7.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,13 @@
+# 7.9.0
+
+* Updates the Messages API implementation to ass support for `video` and `file` messages types to the Viber channel, and `sticker` messages in the WhatsApp channel. [#260](https://github.com/Vonage/vonage-ruby-sdk/pull/260)
+* Updates the Numbers API implementation to use Basic authentication. [#262](https://github.com/Vonage/vonage-ruby-sdk/pull/262)
+
 # 7.8.2
 
 * Updates the GSM::CHARACTERS constant to remove `ç` and instead add `Ç`. Fixes [#256](https://github.com/Vonage/vonage-ruby-sdk/issues/255)
 * Updates code comments for `SMS#send` method to remove properties for unsupported message types `vCal`, `vCard`, and `wappush`
-* Updates namespacing for referencing `SecurityUtils#secure_compare` method due to change in `ruby-jwt ` gem dependency. 
+* Updates namespacing for referencing `SecurityUtils#secure_compare` method due to change in `ruby-jwt ` gem dependency.
 
 # 7.8.1
 

--- a/lib/vonage/messaging/channels/viber.rb
+++ b/lib/vonage/messaging/channels/viber.rb
@@ -2,7 +2,7 @@
 
 module Vonage
   class Messaging::Channels::Viber  < Messaging::Message
-    MESSAGE_TYPES = ['text', 'image']
+    MESSAGE_TYPES = ['text', 'image', 'video', 'file']
 
     attr_reader :data
 
@@ -31,6 +31,13 @@ module Vonage
       when 'text'
         raise Vonage::ClientError.new(":message must be a String") unless message.is_a? String
       when 'image'
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
+      when 'video'
+        raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
+        raise Vonage::ClientError.new(":thumb_url is required in :message") unless message[:thumb_url]
+      when 'file'
         raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
         raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
       end

--- a/lib/vonage/messaging/channels/whats_app.rb
+++ b/lib/vonage/messaging/channels/whats_app.rb
@@ -2,7 +2,7 @@
 
 module Vonage
   class Messaging::Channels::WhatsApp < Messaging::Message
-    MESSAGE_TYPES = ['text', 'image', 'audio', 'video', 'file', 'template', 'custom']
+    MESSAGE_TYPES = ['text', 'image', 'audio', 'video', 'file', 'template', 'sticker', 'custom']
 
     attr_reader :data
 
@@ -35,6 +35,8 @@ module Vonage
         raise Vonage::ClientError.new(":name is required in :template") unless message[:name]
         raise Vonage::ClientError.new(":whatsapp is required in :opts") unless opts[:whatsapp]
         raise Vonage::ClientError.new(":locale is required in :whatsapp") unless opts[:whatsapp][:locale]
+      when 'sticker'
+        raise Vonage::ClientError.new(":message must contain either :id or :url") unless message.has_key?(:id) ^ message.has_key?(:url)
       when 'custom'
         raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
       else

--- a/lib/vonage/numbers.rb
+++ b/lib/vonage/numbers.rb
@@ -5,6 +5,8 @@ module Vonage
   class Numbers < Namespace
     include Keys
 
+    self.authentication = Basic
+
     self.host = :rest_host
 
     # Retrieve all the inbound numbers associated with your Vonage account.
@@ -52,7 +54,7 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#getOwnedNumbers
     #
     def list(params = nil)
-      request('/account/numbers', params: params, response_class: ListResponse)
+      request("/account/numbers", params: params, response_class: ListResponse)
     end
 
     # Retrieve inbound numbers that are available for the specified country.
@@ -100,7 +102,7 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#getAvailableNumbers
     #
     def search(params)
-      request('/number/search', params: params, response_class: ListResponse)
+      request("/number/search", params: params, response_class: ListResponse)
     end
 
     # Request to purchase a specific inbound number.
@@ -125,7 +127,12 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#buyANumber
     #
     def buy(params)
-      request('/number/buy', params: params, type: Post, response_class: Response)
+      request(
+        "/number/buy",
+        params: params,
+        type: Post,
+        response_class: Response
+      )
     end
 
     # Cancel your subscription for a specific inbound number.
@@ -150,7 +157,12 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#cancelANumber
     #
     def cancel(params)
-      request('/number/cancel', params: params, type: Post, response_class: Response)
+      request(
+        "/number/cancel",
+        params: params,
+        type: Post,
+        response_class: Response
+      )
     end
 
     # Change the behaviour of a number that you own.
@@ -198,14 +210,25 @@ module Vonage
     # @see https://developer.nexmo.com/api/developer/numbers#updateANumber
     #
     def update(params)
-      request('/number/update', params: camelcase(params), type: Post, response_class: Response)
+      request(
+        "/number/update",
+        params: camelcase(params),
+        type: Post,
+        response_class: Response
+      )
     end
 
     private
 
     # A specific implementation of iterable_request for Numbers, because the Numbers API
     # handles pagination differently to other Vonage APIs
-    def iterable_request(path, response: nil, response_class: nil, params: {}, &block)
+    def iterable_request(
+      path,
+      response: nil,
+      response_class: nil,
+      params: {},
+      &block
+    )
       response = parse(response, response_class)
       params[:index] = 1 unless params.has_key?(:index)
       size = params.fetch(:size, 10)

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.8.2'
+  VERSION = "7.9.0"
 end

--- a/test/vonage/messaging/channels/viber_test.rb
+++ b/test/vonage/messaging/channels/viber_test.rb
@@ -23,6 +23,20 @@ class Vonage::Messaging::Channels::ViberTest < Vonage::Test
     assert_includes viber.data, :image
   end
 
+  def test_with_valid_type_video_specified
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'video', message: { url: 'https://example.com/video.mp4', thumb_url: 'https://example.com/file1.jpg' })
+
+    assert_equal 'video', viber.data[:message_type]
+    assert_includes viber.data, :video
+  end
+
+  def test_with_valid_type_file_specified
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'file', message: { url: 'https://example.com/file.pdf' })
+
+    assert_equal 'file', viber.data[:message_type]
+    assert_includes viber.data, :file
+  end
+
   def test_with_invalid_type_specified
     exception = assert_raises {
       viber = Vonage::Messaging::Channels::Viber.new(type: 'audio', message: { url: 'https://example.com/audio.mp3' })
@@ -50,6 +64,33 @@ class Vonage::Messaging::Channels::ViberTest < Vonage::Test
   def test_image_without_url
     exception = assert_raises {
       viber = Vonage::Messaging::Channels::Viber.new(type: 'image', message: {})
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":url is required in :message", exception.message
+  end
+
+  def test_video_without_url
+    exception = assert_raises {
+      viber = Vonage::Messaging::Channels::Viber.new(type: 'video', message: { thumb_url: 'https://example.com/file1.jpg' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":url is required in :message", exception.message
+  end
+
+  def test_video_without_thumb_url
+    exception = assert_raises {
+      viber = Vonage::Messaging::Channels::Viber.new(type: 'video', message: { url: 'https://example.com/video.mp4' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":thumb_url is required in :message", exception.message
+  end
+
+  def test_file_without_url
+    exception = assert_raises {
+      viber = Vonage::Messaging::Channels::Viber.new(type: 'file', message: {})
     }
 
     assert_instance_of Vonage::ClientError, exception

--- a/test/vonage/messaging/channels/whats_app_test.rb
+++ b/test/vonage/messaging/channels/whats_app_test.rb
@@ -44,6 +44,22 @@ class Vonage::Messaging::Channels::WhatsAppTest < Vonage::Test
     assert_includes whatsapp.data, :file
   end
 
+  def test_with_valid_type_sticker_specified_with_url
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'sticker', message: { url: 'https://example.com/file.webp' })
+
+    assert_equal 'sticker', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :sticker
+    assert_includes whatsapp.data[:sticker], :url
+  end
+
+  def test_with_valid_type_sticker_specified_with_id
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'sticker', message: { id: '16aec2a6-bf69-11ed-afa1-0242ac120002' })
+
+    assert_equal 'sticker', whatsapp.data[:message_type]
+    assert_includes whatsapp.data, :sticker
+    assert_includes whatsapp.data[:sticker], :id
+  end
+
   def test_with_invalid_type_specified
     exception = assert_raises {
       whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'vcard', message: { url: 'https://example.com/contact.vcf' })
@@ -111,6 +127,24 @@ class Vonage::Messaging::Channels::WhatsAppTest < Vonage::Test
 
     assert_instance_of Vonage::ClientError, exception
     assert_match ":message must be a Hash", exception.message
+  end
+
+  def test_sticker_without_id_or_url
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'sticker', message: {})
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must contain either :id or :url", exception.message
+  end
+
+  def test_sticker_with_both_id_and_url
+    exception = assert_raises {
+      whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'sticker', message: { url: 'https://example.com/file.webp', id: '16aec2a6-bf69-11ed-afa1-0242ac120002' })
+    }
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ":message must contain either :id or :url", exception.message
   end
 
   def test_with_opts_client_ref

--- a/test/vonage/numbers_test.rb
+++ b/test/vonage/numbers_test.rb
@@ -1,5 +1,5 @@
 # typed: false
-require_relative './test'
+require_relative "./test"
 
 class Vonage::NumbersTest < Vonage::Test
   def numbers
@@ -7,45 +7,49 @@ class Vonage::NumbersTest < Vonage::Test
   end
 
   def test_list_method
-    uri = 'https://rest.nexmo.com/account/numbers'
+    uri = "https://rest.nexmo.com/account/numbers"
 
-    params = {size: 25, pattern: '33'}
+    params = { size: 25, pattern: "33" }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(numbers_response)
+    stub_request(:get, uri).with(query: params).to_return(numbers_response)
 
     response = numbers.list(params)
 
-    response.each{|resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
+    response.each { |resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
   end
 
   def test_list_method_without_args
-    uri = 'https://rest.nexmo.com/account/numbers'
+    uri = "https://rest.nexmo.com/account/numbers"
 
-    stub_request(:get, uri).with(query: api_key_and_secret).to_return(numbers_response)
+    stub_request(:get, uri).to_return(numbers_response)
 
     response = numbers.list
 
-    response.each{|resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
+    response.each { |resp| assert_kind_of Vonage::Numbers::ListResponse, resp }
   end
 
   def test_search_method
-    uri = 'https://rest.nexmo.com/number/search'
+    uri = "https://rest.nexmo.com/number/search"
 
-    params = {size: 25, country: country}
+    params = { size: 25, country: country }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:get, uri).with(query: params).to_return(response)
 
     assert_kind_of Vonage::Numbers::ListResponse, numbers.search(params)
   end
 
   def test_search_method_with_auto_advance
-    uri = 'https://rest.nexmo.com/number/search'
+    uri = "https://rest.nexmo.com/number/search"
 
-    params = {country: country}
+    params = { country: country }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(numbers_response_paginated_page_1)
+    stub_request(:get, uri).with(query: params).to_return(
+      numbers_response_paginated_page_1
+    )
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret.merge(index: 2))).to_return(numbers_response_paginated_page_2)
+    stub_request(:get, uri).with(query: params.merge(index: 2)).to_return(
+      numbers_response_paginated_page_2
+    )
 
     response = numbers.search(params.merge(auto_advance: true))
 
@@ -54,11 +58,13 @@ class Vonage::NumbersTest < Vonage::Test
   end
 
   def test_search_method_with_auto_advance_with_index_offset_by_one_page
-    uri = 'https://rest.nexmo.com/number/search'
+    uri = "https://rest.nexmo.com/number/search"
 
-    params = {country: country}
+    params = { country: country }
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret.merge(index: 2))).to_return(numbers_response_paginated_page_2)
+    stub_request(:get, uri).with(query: params.merge(index: 2)).to_return(
+      numbers_response_paginated_page_2
+    )
 
     response = numbers.search(params.merge(auto_advance: true, index: 2))
 
@@ -67,34 +73,49 @@ class Vonage::NumbersTest < Vonage::Test
   end
 
   def test_buy_method
-    uri = 'https://rest.nexmo.com/number/buy'
+    uri = "https://rest.nexmo.com/number/buy"
 
-    params = {country: country, msisdn: msisdn}
+    params = { country: country, msisdn: msisdn }
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(headers: headers, body: params).to_return(
+      response
+    )
 
     assert_kind_of Vonage::Numbers::Response, numbers.buy(params)
   end
 
   def test_cancel_method
-    uri = 'https://rest.nexmo.com/number/cancel'
+    uri = "https://rest.nexmo.com/number/cancel"
 
-    params = {country: country, msisdn: msisdn}
+    params = { country: country, msisdn: msisdn }
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(headers: headers, body: params).to_return(
+      response
+    )
 
     assert_kind_of Vonage::Numbers::Response, numbers.cancel(params)
   end
 
   def test_update_method
-    uri = 'https://rest.nexmo.com/number/update'
+    uri = "https://rest.nexmo.com/number/update"
 
-    mo_http_url = 'https://example.com/callback'
+    mo_http_url = "https://example.com/callback"
 
-    params = {'country' => country, 'msisdn' => msisdn, 'moHttpUrl' => mo_http_url}
+    params = {
+      "country" => country,
+      "msisdn" => msisdn,
+      "moHttpUrl" => mo_http_url
+    }
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(headers: headers, body: params).to_return(
+      response
+    )
 
-    assert_kind_of Vonage::Numbers::Response, numbers.update(country: country, msisdn: msisdn, mo_http_url: mo_http_url)
+    assert_kind_of Vonage::Numbers::Response,
+                   numbers.update(
+                     country: country,
+                     msisdn: msisdn,
+                     mo_http_url: mo_http_url
+                   )
   end
 end


### PR DESCRIPTION
This PR:

* Updates the Messages API implementation to ass support for `video` and `file` messages types to the Viber channel, and `sticker` messages in the WhatsApp channel. [#260](https://github.com/Vonage/vonage-ruby-sdk/pull/260)
* Updates the Numbers API implementation to use Basic authentication. [#262](https://github.com/Vonage/vonage-ruby-sdk/pull/262)