### PR TITLE
Add Instagram Support

### DIFF
--- a/lib/vonage/messaging/channels/instagram.rb
+++ b/lib/vonage/messaging/channels/instagram.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# typed: true
+
+module Vonage
+  class Messaging::Channels::Instagram < Messaging::Message
+    MESSAGE_TYPES = %w[text image audio video file].freeze
+
+    attr_reader :data
+
+    # initializes a Vonage::Message for Instagram
+    # @param [Hash] attributes
+    def initialize(attributes = {})
+      @type = attributes.fetch(:type, nil)
+      @message = attributes.fetch(:message, nil)
+      @opts = attributes.fetch(:opts, {})
+      @data = {}
+
+      after_initialize!
+    end
+
+    private
+
+    # sets channel to 'instagram' and calls super creating a Vonage::Message
+    #   to be sent via SDK
+    # @return Message
+    def build
+      data[:channel] = 'instagram'
+      super
+    end
+
+    # raises ClientError if message has an invalid type from defined 
+    #   MESSAGE_TYPES
+    # @raise [Vonage::ClientError]
+    def verify_type
+      raise Vonage::ClientError, 'Invalid message type' unless
+        MESSAGE_TYPES.include?(type)
+    end
+
+    # raises ClientError if message has invalid arguments
+    # @raise [Vonage::ClientError]
+    # @return nil
+    def verify_message
+      case type
+      when 'text'
+        raise Vonage::ClientError, ':message must be a String' unless
+          message.is_a? String
+      else
+        raise Vonage::ClientError, ':message must be a Hash' unless
+          message.is_a? Hash
+        raise Vonage::ClientError, ':url is required in :message' unless
+          message[:url]
+      end
+    end
+  end
+end

--- a/lib/vonage/messaging/message.rb
+++ b/lib/vonage/messaging/message.rb
@@ -7,7 +7,8 @@ module Vonage
       mms: Vonage::Messaging::Channels::MMS,
       whatsapp: Vonage::Messaging::Channels::WhatsApp,
       messenger: Vonage::Messaging::Channels::Messenger,
-      viber: Vonage::Messaging::Channels::Viber
+      viber: Vonage::Messaging::Channels::Viber,
+      instagram: Vonage::Messaging::Channels::Instagram
     }
 
     class << self

--- a/test/vonage/messaging/channels/instagram_test.rb
+++ b/test/vonage/messaging/channels/instagram_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+# typed: false
+
+class Vonage::Messaging::Channels::MessengerTest < Vonage::Test
+  def test_instagram_initialize
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'text', message: 'Hello world!'
+    )
+
+    assert_kind_of Vonage::Messaging::Channels::Instagram, message
+    assert_equal message.data, {
+      channel: 'instagram', message_type: 'text', text: 'Hello world!'
+    }
+  end
+
+  def test_with_valid_type_text_specified
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'text', message: 'Hello world!'
+    )
+
+    assert_equal 'text', message.data[:message_type]
+    assert_includes message.data, :text
+  end
+
+  def test_with_valid_type_image_specified
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'image',
+      message: { url: 'https://example.com/image.jpg' }
+    )
+
+    assert_equal 'image', message.data[:message_type]
+    assert_includes message.data, :image
+  end
+
+  def test_with_valid_type_audio_specified
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'audio',
+      message: { url: 'https://example.com/audio.mp3' }
+    )
+
+    assert_equal 'audio', message.data[:message_type]
+    assert_includes message.data, :audio
+  end
+
+  def test_with_valid_type_video_specified
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'video',
+      message: { url: 'https://example.com/video.mp4' }
+    )
+
+    assert_equal 'video', message.data[:message_type]
+    assert_includes message.data, :video
+  end
+
+  def test_with_valid_type_file_specified
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'file',
+      message: { url: 'https://example.com/file.pdf' }
+    )
+
+    assert_equal 'file', message.data[:message_type]
+    assert_includes message.data, :file
+  end
+
+  def test_with_invalid_type_specified
+    exception = assert_raises do
+      Vonage::Messaging::Channels::Instagram.new(
+        type: 'vcard',
+        message: { url: 'https://example.com/contact.vcf' }
+      )
+    end
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match 'Invalid message type', exception.message
+  end
+
+  def test_with_valid_message_class
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'image',
+      message: { url: 'https://example.com/image.jpg' }
+    )
+
+    assert_kind_of Hash, message.data[:image]
+  end
+
+  def test_with_invalid_message_class
+    exception = assert_raises do
+      Vonage::Messaging::Channels::Instagram.new(
+        type: 'image', message: 'https://example.com/image.jpg'
+      )
+    end
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ':message must be a Hash', exception.message
+  end
+
+  def test_object_message_without_url
+    exception = assert_raises do
+      Vonage::Messaging::Channels::Instagram.new(
+        type: 'image',
+        message: {}
+      )
+    end
+
+    assert_instance_of Vonage::ClientError, exception
+    assert_match ':url is required in :message', exception.message
+  end
+
+  def test_with_opts_client_ref
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'text',
+      message: 'Hello world!',
+      opts: { client_ref: 'abc123' }
+    )
+
+    assert_equal 'abc123', message.data[:client_ref]
+  end
+
+  def test_with_opts_instagram_object
+    message = Vonage::Messaging::Channels::Instagram.new(
+      type: 'text',
+      message: 'Hello world!',
+      opts: {
+        instagram: { 
+          category: 'response', 
+          tag: 'CONFIRMED_EVENT_UPDATE' 
+        }
+      }
+    )
+
+    assert_equal 'response', message.data[:instagram][:category]
+    assert_equal 'CONFIRMED_EVENT_UPDATE', message.data[:instagram][:tag]
+  end
+end


### PR DESCRIPTION
# Instagram Support

- Adds Support for Instagram by adding a new channel: `Messaging::Channels::Instagram`
- Tests for Messages contents edge cases for text, image, audio and video

## Usage

```ruby
vonage_client = Vonage::Client.new(...) # auth credentials
message = Vonage::Messaging::Message.instagram(
  type: 'text',
  message: 'This is an Instagram text message sent using the Messages API'
)
vonage_client.messaging.send(
  from: 'YOUR-INSTAGRAM-ID',
  to: 'USER-INSTAGRAM-ID',
  **message
)
```