### PR TITLE
DEVX-7400: Add Subaccounts API

### DIFF
--- a/lib/vonage/client.rb
+++ b/lib/vonage/client.rb
@@ -117,7 +117,7 @@ module Vonage
       @sms ||= T.let(SMS.new(config), T.nilable(Vonage::SMS))
     end
 
-    # @return [SMS]
+    # @return [Subaccounts]
     #
     sig { returns(T.nilable(Vonage::Subaccounts)) }
     def subaccounts

--- a/lib/vonage/client.rb
+++ b/lib/vonage/client.rb
@@ -117,6 +117,13 @@ module Vonage
       @sms ||= T.let(SMS.new(config), T.nilable(Vonage::SMS))
     end
 
+    # @return [SMS]
+    #
+    sig { returns(T.nilable(Vonage::Subaccounts)) }
+    def subaccounts
+      @subaccounts ||= T.let(Subaccounts.new(config), T.nilable(Vonage::Subaccounts))
+    end
+
     # @return [TFA]
     #
     sig { returns(T.nilable(Vonage::TFA)) }

--- a/lib/vonage/namespace.rb
+++ b/lib/vonage/namespace.rb
@@ -51,6 +51,7 @@ module Vonage
 
     Get = Net::HTTP::Get
     Put = Net::HTTP::Put
+    Patch = Net::HTTP::Patch
     Post = Net::HTTP::Post
     Delete = Net::HTTP::Delete
 

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -21,8 +21,8 @@ module Vonage
       request("/accounts/#{@config.api_key}/subaccounts", params: params.merge(name: name), type: Post)
     end
 
-    def update
-
+    def update(subaccount_key:, **params)
+      request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}", params: params, type: Patch)
     end
 
     def list_credit_transfers

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -88,8 +88,9 @@ module Vonage
     # @example
     #   response = client.subaccounts.list_credit_transfers(start_date: "2023-06-15T15:53:50Z")
     #
-    # @option params [required, String] :start_date
+    # @option params [optional, String] :start_date
     #   The ISO format datetime from which to list transfers. Example: 2019-03-02T16:34:49Z.
+    #   Defaults to "1970-01-01T00:00:00Z" if omitted
     #
     # @option params [optional, String] :end_date
     #   The ISO format datetime to which to list transfers. Example: 2019-03-02T16:34:49Z.
@@ -100,7 +101,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/subaccounts#retrieveCreditTransfers
     #
-    def list_credit_transfers(start_date:, **params)
+    def list_credit_transfers(start_date: "1970-01-01T00:00:00Z", **params)
       path = "/accounts/#{@config.api_key}/credit-transfers?#{Params.encode(params.merge(start_date: start_date))}"
 
       request(path, response_class: CreditTransfers::ListResponse)
@@ -134,8 +135,9 @@ module Vonage
     # @example
     #   response = client.subaccounts.list_balance_transfers(start_date: "2023-06-15T15:53:50Z")
     #
-    # @option params [required, String] :start_date
+    # @option params [optional, String] :start_date
     #   The ISO format datetime from which to list transfers. Example: 2019-03-02T16:34:49Z.
+    #   Defaults to "1970-01-01T00:00:00Z" if omitted
     #
     # @option params [optional, String] :end_date
     #   The ISO format datetime to which to list transfers. Example: 2019-03-02T16:34:49Z.
@@ -146,7 +148,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/subaccounts#retrieveBalanceTransfers
     #
-    def list_balance_transfers(start_date:, **params)
+    def list_balance_transfers(start_date: "1970-01-01T00:00:00Z", **params)
       path = "/accounts/#{@config.api_key}/balance-transfers?#{Params.encode(params.merge(start_date: start_date))}"
 
       request(path, response_class: BalanceTransfers::ListResponse)
@@ -190,7 +192,7 @@ module Vonage
     #   The number to transfer
     #
     # @option params [required, String] :country
-    #   A code representing the country for the number, e.g. GB.
+    #   An ISO-3166-1 alpha 2 code representing the country for the number, e.g. GB.
     #
     # @see https://developer.vonage.com/en/api/subaccounts#transferNumber
     #

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module Vonage
-  class Account < Namespace
+  class Subaccounts < Namespace
 
     self.host = :rest_host
 

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -41,8 +41,8 @@ module Vonage
       request("/accounts/#{@config.api_key}/balance-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
-    def transfer_number
-
+    def transfer_number(from:, to:, number:, **params)
+      request("/accounts/#{@config.api_key}/transfer-number", params: params.merge(from: from, to: to, number: number), type: Post)
     end
   end
 end

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -29,8 +29,8 @@ module Vonage
 
     end
 
-    def transfer_credit
-
+    def transfer_credit(from:, to:, amount:, **params)
+      request("/accounts/#{@config.api_key}/credit-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
     def list_balance_transfers

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -1,0 +1,45 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Vonage
+  class Account < Namespace
+
+    self.host = :rest_host
+
+    def list
+
+    end
+
+    def find
+
+    end
+
+    def create
+
+    end
+
+    def update
+
+    end
+
+    def list_credit_transfers
+
+    end
+
+    def transfer_credit
+
+    end
+
+    def list_balance_transfers
+
+    end
+
+    def transfer_balance
+
+    end
+
+    def transfer_number
+
+    end
+  end
+end

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -37,8 +37,8 @@ module Vonage
 
     end
 
-    def transfer_balance
-
+    def transfer_balance(from:, to:, amount:, **params)
+      request("/accounts/#{@config.api_key}/balance-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
     def transfer_number

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -36,8 +36,11 @@ module Vonage
       request("/accounts/#{@config.api_key}/credit-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
-    def list_balance_transfers
+    def list_balance_transfers(**params)
+      path = "/accounts/#{@config.api_key}/balance-transfers"
+      path += "?#{Params.encode(params)}" unless params.empty?
 
+      request(path, response_class: BalanceTransfers::ListResponse)
     end
 
     def transfer_balance(from:, to:, amount:, **params)

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -7,42 +7,193 @@ module Vonage
 
     self.request_body = JSON
 
+    # Retrieve list of subaccounts.
+    #
+    # @example
+    #   response = client.subaccounts.list
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#retrieveSubaccountsList
+    #
     def list
       request("/accounts/#{@config.api_key}/subaccounts", response_class: ListResponse)
     end
 
+    # Retrieve a subaccount.
+    #
+    # @example
+    #   response = client.subaccounts.find(subaccount_key: 'abc123')
+    #
+    # @option params [required, String] :subaccount_key
+    #   The API key for the subaccount you want to retrieve
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#retrieveSubaccount
+    #
     def find(subaccount_key:)
       request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}")
     end
 
+    # Create a subaccount.
+    #
+    # @example
+    #   response = client.subaccounts.create(name: 'Foo')
+    #
+    # @option params [required, String] :name
+    #   The name of the subaccount
+    #
+    # @option params [optional, String] :secret
+    #   An account secret for use by the subaccount. Can be used in combination with your API key to authenticate your API requests.
+    #   Requirements:
+    #     - 8 characters and no more than 25
+    #     - 1 lower-case letter
+    #     - 1 capital letter
+    #     - 1 digit
+    #     - must be unique
+    #
+    # @option params [optional, Boolean] :use_primary_account_balance
+    #   Whether the subaccount uses the primary account balance (true, the default) or has its own balance (false).
+    #   Once set to `false` cannot be changed back to `true`
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#createSubAccount
+    #
     def create(name:, **params)
       request("/accounts/#{@config.api_key}/subaccounts", params: params.merge(name: name), type: Post)
     end
 
+    # Modify a subaccount.
+    #
+    # @example
+    #   response = client.subaccounts.update(name: 'Bar')
+    #
+    # @option params [required, String] :subaccount_key
+    #   The API key for the subaccount you want to modify
+    #
+    # @option params [optional, String] :name
+    #   The name of the subaccount
+    #
+    # @option params [optional, Boolean] :use_primary_account_balance
+    #   Whether the subaccount uses the primary account balance (true, the default) or has its own balance (false).
+    #   Once set to `false` cannot be changed back to `true`
+    #
+    # @option params [optional, String] :suspended
+    #   Whether the subaccount is suspended (true) or not (false, the default)
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#modifySubaccount
+    #
     def update(subaccount_key:, **params)
       request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}", params: params, type: Patch)
     end
 
+    # Retrieve list of credit transfers.
+    #
+    # @example
+    #   response = client.subaccounts.list_credit_transfers(start_date: "2023-06-15T15:53:50Z")
+    #
+    # @option params [required, String] :start_date
+    #   The ISO format datetime from which to list transfers. Example: 2019-03-02T16:34:49Z.
+    #
+    # @option params [optional, String] :end_date
+    #   The ISO format datetime to which to list transfers. Example: 2019-03-02T16:34:49Z.
+    #   If absent then all transfers until now is returned.
+    #
+    # @option params [optional, String] :subaccount
+    #   Subaccount to filter by.
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#retrieveCreditTransfers
+    #
     def list_credit_transfers(start_date:, **params)
       path = "/accounts/#{@config.api_key}/credit-transfers?#{Params.encode(params.merge(start_date: start_date))}"
 
       request(path, response_class: CreditTransfers::ListResponse)
     end
 
+    # Transfer credit.
+    #
+    # @example
+    #   response = client.subaccounts.transfer_credit(from: 'abc123', to: 'def456', amount: 10.00)
+    #
+    # @option params [required, String] :from
+    #   The API key of the account or subaccount to transfer credit from.
+    #
+    # @option params [required, String] :to
+    #   The API key of the account or subaccount to transfer credit to.
+    #
+    # @option params [required, Number] :amount
+    #   The amount to transfer
+    #
+    # @option params [optional, String] :reference
+    #   A reference for the transfer.
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#transferCredit
+    #
     def transfer_credit(from:, to:, amount:, **params)
       request("/accounts/#{@config.api_key}/credit-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
+    # Retrieve list of balance transfers.
+    #
+    # @example
+    #   response = client.subaccounts.list_balance_transfers(start_date: "2023-06-15T15:53:50Z")
+    #
+    # @option params [required, String] :start_date
+    #   The ISO format datetime from which to list transfers. Example: 2019-03-02T16:34:49Z.
+    #
+    # @option params [optional, String] :end_date
+    #   The ISO format datetime to which to list transfers. Example: 2019-03-02T16:34:49Z.
+    #   If absent then all transfers until now is returned.
+    #
+    # @option params [optional, String] :subaccount
+    #   Subaccount to filter by.
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#retrieveBalanceTransfers
+    #
     def list_balance_transfers(start_date:, **params)
       path = "/accounts/#{@config.api_key}/balance-transfers?#{Params.encode(params.merge(start_date: start_date))}"
 
       request(path, response_class: BalanceTransfers::ListResponse)
     end
 
+    # Transfer balance.
+    #
+    # @example
+    #   response = client.subaccounts.transfer_balance(from: 'abc123', to: 'def456', amount: 10.00)
+    #
+    # @option params [required, String] :from
+    #   The API key of the account or subaccount to transfer balance from.
+    #
+    # @option params [required, String] :to
+    #   The API key of the account or subaccount to transfer balance to.
+    #
+    # @option params [required, Number] :amount
+    #   The amount to transfer
+    #
+    # @option params [optional, String] :reference
+    #   A reference for the transfer.
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#transferBalance
+    #
     def transfer_balance(from:, to:, amount:, **params)
       request("/accounts/#{@config.api_key}/balance-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
+    # Transfer number.
+    #
+    # @example
+    #   response = client.subaccounts.transfer_number(from: 'abc123', to: 'def456', number: 447900000000, country: 'GB')
+    #
+    # @option params [required, String] :from
+    #   The API key of the account or subaccount to transfer the number from.
+    #
+    # @option params [required, String] :to
+    #   The API key of the account or subaccount to transfer the number to.
+    #
+    # @option params [required, Number] :number
+    #   The number to transfer
+    #
+    # @option params [required, String] :country
+    #   A code representing the country for the number, e.g. GB.
+    #
+    # @see https://developer.vonage.com/en/api/subaccounts#transferNumber
+    #
     def transfer_number(from:, to:, number:, country:)
       request("/accounts/#{@config.api_key}/transfer-number", params: {from: from, to: to, number: number, country: country}, type: Post)
     end

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -10,7 +10,7 @@ module Vonage
     self.request_body = JSON
 
     def list
-
+      request("/accounts/#{@config.api_key}/subaccounts", response_class: ListResponse)
     end
 
     def find(subaccount_key:)

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -3,15 +3,18 @@
 
 module Vonage
   class Subaccounts < Namespace
+    self.authentication = Basic
 
     self.host = :rest_host
+
+    self.request_body = JSON
 
     def list
 
     end
 
-    def find
-
+    def find(subaccount_key:)
+      request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}")
     end
 
     def create

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -25,8 +25,11 @@ module Vonage
       request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}", params: params, type: Patch)
     end
 
-    def list_credit_transfers
+    def list_credit_transfers(**params)
+      path = "/accounts/#{@config.api_key}/credit-transfers"
+      path += "?#{Params.encode(params)}" unless params.empty?
 
+      request(path, response_class: CreditTransfers::ListResponse)
     end
 
     def transfer_credit(from:, to:, amount:, **params)

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -23,9 +23,8 @@ module Vonage
       request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}", params: params, type: Patch)
     end
 
-    def list_credit_transfers(**params)
-      path = "/accounts/#{@config.api_key}/credit-transfers"
-      path += "?#{Params.encode(params)}" unless params.empty?
+    def list_credit_transfers(start_date:, **params)
+      path = "/accounts/#{@config.api_key}/credit-transfers?#{Params.encode(params.merge(start_date: start_date))}"
 
       request(path, response_class: CreditTransfers::ListResponse)
     end
@@ -34,9 +33,8 @@ module Vonage
       request("/accounts/#{@config.api_key}/credit-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
-    def list_balance_transfers(**params)
-      path = "/accounts/#{@config.api_key}/balance-transfers"
-      path += "?#{Params.encode(params)}" unless params.empty?
+    def list_balance_transfers(start_date:, **params)
+      path = "/accounts/#{@config.api_key}/balance-transfers?#{Params.encode(params.merge(start_date: start_date))}"
 
       request(path, response_class: BalanceTransfers::ListResponse)
     end
@@ -45,8 +43,8 @@ module Vonage
       request("/accounts/#{@config.api_key}/balance-transfers", params: params.merge(from: from, to: to, amount: amount), type: Post)
     end
 
-    def transfer_number(from:, to:, number:, **params)
-      request("/accounts/#{@config.api_key}/transfer-number", params: params.merge(from: from, to: to, number: number), type: Post)
+    def transfer_number(from:, to:, number:, country:)
+      request("/accounts/#{@config.api_key}/transfer-number", params: {from: from, to: to, number: number, country: country}, type: Post)
     end
   end
 end

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -5,8 +5,6 @@ module Vonage
   class Subaccounts < Namespace
     self.authentication = Basic
 
-    self.host = :rest_host
-
     self.request_body = JSON
 
     def list

--- a/lib/vonage/subaccounts.rb
+++ b/lib/vonage/subaccounts.rb
@@ -17,8 +17,8 @@ module Vonage
       request("/accounts/#{@config.api_key}/subaccounts/#{subaccount_key}")
     end
 
-    def create
-
+    def create(name:, **params)
+      request("/accounts/#{@config.api_key}/subaccounts", params: params.merge(name: name), type: Post)
     end
 
     def update

--- a/lib/vonage/subaccounts/balance_transfers/list_response.rb
+++ b/lib/vonage/subaccounts/balance_transfers/list_response.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Vonage::Subaccounts::BalanceTransfers::ListResponse < Vonage::Response
+  include Enumerable
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    @entity._embedded.balance_transfers.each { |item| yield item }
+  end
+end

--- a/lib/vonage/subaccounts/credit_transfers/list_response.rb
+++ b/lib/vonage/subaccounts/credit_transfers/list_response.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Vonage::Subaccounts::CreditTransfers::ListResponse < Vonage::Response
+  include Enumerable
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    @entity._embedded.credit_transfers.each { |item| yield item }
+  end
+end

--- a/lib/vonage/subaccounts/list_response.rb
+++ b/lib/vonage/subaccounts/list_response.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class Vonage::Subaccounts::ListResponse < Vonage::Response
+  include Enumerable
+
+  def primary_account
+    @entity._embedded.primary_account
+  end
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    @entity._embedded.subaccounts.each { |item| yield item }
+  end
+end

--- a/test/vonage/client_test.rb
+++ b/test/vonage/client_test.rb
@@ -70,6 +70,10 @@ class Vonage::ClientTest < Vonage::Test
     assert_kind_of Vonage::SMS, client.sms
   end
 
+  def test_subaccounts_method
+    assert_kind_of Vonage::Subaccounts, client.subaccounts
+  end
+
   def test_tfa_method
     assert_kind_of Vonage::TFA, client.tfa
   end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -145,15 +145,14 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_balance_method
-    skip
-    stub_request(:post, "/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" })).to_return(response)
+    stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45")
   end
 
   def test_transfer_balance_method_with_optional_params
     skip
-    stub_request(:post, "/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" })).to_return(response)
+    stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
   end
@@ -181,14 +180,14 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_transfer_number_method
     skip
-    stub_request(:post, "/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696 })).to_return(response)
+    stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696 }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", number: 23507703696)
   end
 
   def test_transfer_number_method_with_optional_params
     skip
-    stub_request(:post, "/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' })).to_return(response)
+    stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", number: 23507703696, country: 'GB' )
   end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -27,7 +27,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_find_method
-    stub_request(:get, subaccounts_uri + "/#{subaccount_api_key}").to_return(response)
+    stub_request(:get, "#{subaccounts_uri}/#{subaccount_api_key}").to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.find(subaccount_key: subaccount_api_key)
   end
@@ -57,10 +57,15 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_update_method
-    skip
-    stub_request(:patch, "/#{subaccount_api_key}").with(request(body: { name: "Bar" })).to_return(response)
+    stub_request(:patch, "#{subaccounts_uri}/#{subaccount_api_key}").with(request(body: { name: "Bar" }, auth: basic_authorization)).to_return(response)
 
-    assert_kind_of Vonage::Response, subaccounts.update(name: "Bar")
+    assert_kind_of Vonage::Response, subaccounts.update(subaccount_key: subaccount_api_key, name: "Bar")
+  end
+
+  def test_update_method_without_subaccount_key
+    assert_raises ArgumentError do
+      subaccounts.update
+    end
   end
 
   def test_list_credit_transfers_method

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -6,8 +6,12 @@ class Vonage::SubaccountsTest < Vonage::Test
     Vonage::Subaccounts.new(config)
   end
 
+  def accounts_uri
+    "https://rest.nexmo.com/accounts/#{api_key}"
+  end
+
   def subaccounts_uri
-    "https://rest.nexmo.com/accounts/#{api_key}/subaccounts"
+    "#{accounts_uri}/subaccounts"
   end
 
   def subaccount_api_key
@@ -90,35 +94,30 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_credit_method
-    skip
-    stub_request(:post, "/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" })).to_return(response)
+    stub_request(:post, "#{accounts_uri}/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_credit(from: "abc123", to: "def456", amount: "123.45")
   end
 
   def test_transfer_credit_method_with_optional_params
-    skip
-    stub_request(:post, "/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" })).to_return(response)
+    stub_request(:post, "#{accounts_uri}/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_credit(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
   end
 
   def test_transfer_credit_method_without_from
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_credit(to: "def456", amount: "123.45")
     end
   end
 
   def test_transfer_credit_method_without_to
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_credit(from: "abc123", amount: "123.45")
     end
   end
 
   def test_transfer_credit_method_without_amount
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_credit(from: "abc123", to: "def456")
     end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -151,63 +151,54 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_balance_method_with_optional_params
-    skip
     stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
   end
 
   def test_transfer_balance_method_without_from
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_balance(to: "def456", amount: "123.45")
     end
   end
 
   def test_transfer_balance_method_without_to
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_balance(from: "abc123", amount: "123.45")
     end
   end
 
   def test_transfer_balance_method_without_amount
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_balance(from: "abc123", to: "def456")
     end
   end
 
   def test_transfer_number_method
-    skip
     stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696 }, auth: basic_authorization)).to_return(response)
 
-    assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", number: 23507703696)
+    assert_kind_of Vonage::Response, subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696)
   end
 
   def test_transfer_number_method_with_optional_params
-    skip
     stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' }, auth: basic_authorization)).to_return(response)
 
-    assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", number: 23507703696, country: 'GB' )
+    assert_kind_of Vonage::Response, subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696, country: 'GB' )
   end
 
   def test_transfer_number_method_without_from
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_number(to: "def456", number: 23507703696)
     end
   end
 
   def test_transfer_number_method_without_to
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_number(from: "abc123", number: 23507703696)
     end
   end
 
   def test_transfer_number_method_without_amount
-    skip
     assert_raises ArgumentError do
       subaccounts.transfer_number(from: "abc123", to: "def456")
     end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -16,7 +16,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_method
     skip
-    stub_request(:get, uri).to_return(subaccounts_list_response)
+    stub_request(:get, subaccounts_uri).to_return(subaccounts_list_response)
 
     subaccounts_list = subaccounts.list
 
@@ -27,14 +27,12 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_find_method
-    skip
-    stub_request(:get, uri + "/#{subaccount_api_key}").to_return(response)
+    stub_request(:get, subaccounts_uri + "/#{subaccount_api_key}").to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.find(subaccount_key: subaccount_api_key)
   end
 
   def test_find_method_without_subaccount_key
-    skip
     assert_raises ArgumentError do
       subaccounts.find
     end
@@ -42,14 +40,14 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_create_method
     skip
-    stub_request(:post, uri).with(request(body: { name: "Foo" })).to_return(response)
+    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.create(name: "Foo")
   end
 
   def test_create_method_with_optional_params
     skip
-    stub_request(:post, uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false })).to_return(response)
+    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.create(name: "Foo", secret: "Password123", use_primary_account_balance: false)
   end
@@ -70,7 +68,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_credit_transfers_method
     skip
-    stub_request(:get, uri + "/credit-transfers").to_return(credit_transfers_list_response)
+    stub_request(:get, subaccounts_uri + "/credit-transfers").to_return(credit_transfers_list_response)
 
     credit_transfers_list = subaccounts.list_credit_transfers
 
@@ -81,7 +79,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   def test_list_credit_transfers_method_with_optional_params
     skip
     query = "?subaccount=abc123"
-    stub_request(:get, uri + "/credit-transfers" + query).to_return(credit_transfers_list_response_filtered)
+    stub_request(:get, subaccounts_uri + "/credit-transfers" + query).to_return(credit_transfers_list_response_filtered)
 
     credit_transfers_list = subaccounts.list_credit_transfers(subaccount: 'abc123')
 
@@ -126,7 +124,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_balance_transfers_method
     skip
-    stub_request(:get, uri + "/balance-transfers").to_return(balance_transfers_list_response)
+    stub_request(:get, subaccounts_uri + "/balance-transfers").to_return(balance_transfers_list_response)
 
     balance_transfers_list = subaccounts.list_balance_transfers
 
@@ -137,7 +135,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   def test_list_balance_transfers_method_with_optional_params
     skip
     query = "?subaccount=abc123"
-    stub_request(:get, uri + "/balance-transfers" + query).to_return(balance_transfers_list_response_filtered)
+    stub_request(:get, subaccounts_uri + "/balance-transfers" + query).to_return(balance_transfers_list_response_filtered)
 
     balance_transfers_list = subaccounts.list_balance_transfers(subaccount: 'abc123')
 

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -19,7 +19,6 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_method
-    skip
     stub_request(:get, subaccounts_uri).to_return(subaccounts_list_response)
 
     subaccounts_list = subaccounts.list

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -73,8 +73,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_credit_transfers_method
-    skip
-    stub_request(:get, subaccounts_uri + "/credit-transfers").to_return(credit_transfers_list_response)
+    stub_request(:get, "#{accounts_uri}/credit-transfers").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response)
 
     credit_transfers_list = subaccounts.list_credit_transfers
 
@@ -83,9 +82,8 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_credit_transfers_method_with_optional_params
-    skip
     query = "?subaccount=abc123"
-    stub_request(:get, subaccounts_uri + "/credit-transfers" + query).to_return(credit_transfers_list_response_filtered)
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").to_return(credit_transfers_list_response_filtered)
 
     credit_transfers_list = subaccounts.list_credit_transfers(subaccount: 'abc123')
 

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -1,0 +1,329 @@
+# typed: false
+require_relative './test'
+
+class Vonage::SubaccountsTest < Vonage::Test
+  def subaccounts
+    Vonage::Subaccounts.new(config)
+  end
+
+  def subaccounts_uri
+    "https://rest.nexmo.com/accounts/#{api_key}/subaccounts"
+  end
+
+  def subaccount_api_key
+    'vonage-subaccount-api-key'
+  end
+
+  def test_list_method
+    skip
+    stub_request(:get, uri).to_return(subaccounts_list_response)
+
+    subaccounts_list = subaccounts.list
+
+    assert_kind_of Vonage::Subaccounts::ListResponse, subaccounts_list
+    assert_kind_of Vonage::Entity, subaccounts_list.primary_account
+
+    subaccounts_list.each { |subaccount| assert_kind_of Vonage::Entity, subaccount }
+  end
+
+  def test_find_method
+    skip
+    stub_request(:get, uri + "/#{subaccount_api_key}").to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.find(subaccount_key: subaccount_api_key)
+  end
+
+  def test_find_method_without_subaccount_key
+    skip
+    assert_raises ArgumentError do
+      subaccounts.find
+    end
+  end
+
+  def test_create_method
+    skip
+    stub_request(:post, uri).with(request(body: { name: "Foo" })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.create(name: "Foo")
+  end
+
+  def test_create_method_with_optional_params
+    skip
+    stub_request(:post, uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.create(name: "Foo", secret: "Password123", use_primary_account_balance: false)
+  end
+
+  def test_create_method_without_name
+    skip
+    assert_raises ArgumentError do
+      subaccounts.create
+    end
+  end
+
+  def test_update_method
+    skip
+    stub_request(:patch, "/#{subaccount_api_key}").with(request(body: { name: "Bar" })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.update(name: "Bar")
+  end
+
+  def test_list_credit_transfers_method
+    skip
+    stub_request(:get, uri + "/credit-transfers").to_return(credit_transfers_list_response)
+
+    credit_transfers_list = subaccounts.list_credit_transfers
+
+    assert_kind_of Vonage::Subaccounts::CreditTransfers::ListResponse, credit_transfers_list
+    credit_transfers_list.each { |credit_transfer| assert_kind_of Vonage::Entity, credit_transfer }
+  end
+
+  def test_list_credit_transfers_method_with_optional_params
+    skip
+    query = "?subaccount=abc123"
+    stub_request(:get, uri + "/credit-transfers" + query).to_return(credit_transfers_list_response_filtered)
+
+    credit_transfers_list = subaccounts.list_credit_transfers(subaccount: 'abc123')
+
+    assert_kind_of Vonage::Subaccounts::CreditTransfers::ListResponse, credit_transfers_list
+    credit_transfers_list.each { |credit_transfer| assert_kind_of Vonage::Entity, credit_transfer }
+  end
+
+  def test_transfer_credit_method
+    skip
+    stub_request(:post, "/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.transfer_credit(from: "abc123", to: "def456", amount: "123.45")
+  end
+
+  def test_transfer_credit_method_with_optional_params
+    skip
+    stub_request(:post, "/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.transfer_credit(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
+  end
+
+  def test_transfer_credit_method_without_from
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_credit(to: "def456", amount: "123.45")
+    end
+  end
+
+  def test_transfer_credit_method_without_to
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_credit(from: "abc123", amount: "123.45")
+    end
+  end
+
+  def test_transfer_credit_method_without_amount
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_credit(from: "abc123", to: "def456")
+    end
+  end
+
+  def test_list_balance_transfers_method
+    skip
+    stub_request(:get, uri + "/balance-transfers").to_return(balance_transfers_list_response)
+
+    balance_transfers_list = subaccounts.list_balance_transfers
+
+    assert_kind_of Vonage::Subaccounts::BalanceTransfers::ListResponse, balance_transfers_list
+    balance_transfers_list.each { |balance_transfer| assert_kind_of Vonage::Entity, balance_transfer }
+  end
+
+  def test_list_balance_transfers_method_with_optional_params
+    skip
+    query = "?subaccount=abc123"
+    stub_request(:get, uri + "/balance-transfers" + query).to_return(balance_transfers_list_response_filtered)
+
+    balance_transfers_list = subaccounts.list_balance_transfers(subaccount: 'abc123')
+
+    assert_kind_of Vonage::Subaccounts::BalanceTransfers::ListResponse, balance_transfers_list
+    balance_transfers_list.each { |balance_transfer| assert_kind_of Vonage::Entity, balance_transfer }
+  end
+
+  def test_transfer_balance_method
+    skip
+    stub_request(:post, "/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45")
+  end
+
+  def test_transfer_balance_method_with_optional_params
+    skip
+    stub_request(:post, "/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
+  end
+
+  def test_transfer_balance_method_without_from
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_balance(to: "def456", amount: "123.45")
+    end
+  end
+
+  def test_transfer_balance_method_without_to
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_balance(from: "abc123", amount: "123.45")
+    end
+  end
+
+  def test_transfer_balance_method_without_amount
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_balance(from: "abc123", to: "def456")
+    end
+  end
+
+  def test_transfer_number_method
+    skip
+    stub_request(:post, "/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696 })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", number: 23507703696)
+  end
+
+  def test_transfer_number_method_with_optional_params
+    skip
+    stub_request(:post, "/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' })).to_return(response)
+
+    assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", number: 23507703696, country: 'GB' )
+  end
+
+  def test_transfer_number_method_without_from
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_number(to: "def456", number: 23507703696)
+    end
+  end
+
+  def test_transfer_number_method_without_to
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_number(from: "abc123", number: 23507703696)
+    end
+  end
+
+  def test_transfer_number_method_without_amount
+    skip
+    assert_raises ArgumentError do
+      subaccounts.transfer_number(from: "abc123", to: "def456")
+    end
+  end
+
+  def subaccounts_list_response
+    headers: response_headers,
+    body: '{
+      "_embedded": {
+         "primary_account": {
+            "api_key": "bbe6222f",
+            "name": "Subaccount department A",
+            "primary_account_api_key": "acc6111f",
+            "use_primary_account_balance": true,
+            "created_at": "2018-03-02T16:34:49Z",
+            "suspended": false,
+            "balance": 100.25,
+            "credit_limit": -100.25
+         },
+         "subaccounts": [
+            {
+               "api_key": "bbe6222f",
+               "name": "Subaccount department A",
+               "primary_account_api_key": "acc6111f",
+               "use_primary_account_balance": true,
+               "created_at": "2018-03-02T16:34:49Z",
+               "suspended": false,
+               "balance": 100.25,
+               "credit_limit": -100.25
+            }
+         ]
+      }
+   }'
+  end
+
+  def credit_transfers_list_response
+    headers: response_headers,
+    body: '{
+      "_embedded": {
+         "credit-transfers": [
+            {
+               "credit_transfer_id": "07b5-46e1-a527-85530e625800",
+               "amount": 123.45,
+               "from": "7c9738e6",
+               "to": "abc123",
+               "created_at": "2019-03-02T16:34:49Z"
+            },
+            {
+              "credit_transfer_id": "07b5-46e1-a527-85530e625800",
+              "amount": 100.99,
+              "from": "def456",
+              "to": "ad6dc56f",
+              "created_at": "2019-03-02T16:34:49Z"
+           }
+         ]
+      }
+   }'
+  end
+
+  def credit_transfers_list_response_filtered
+    headers: response_headers,
+    body: '{
+      "_embedded": {
+         "credit-transfers": [
+            {
+               "credit_transfer_id": "07b5-46e1-a527-85530e625800",
+               "amount": 123.45,
+               "from": "7c9738e6",
+               "to": "abc123",
+               "created_at": "2019-03-02T16:34:49Z"
+            }
+         ]
+      }
+   }'
+  end
+
+  def balance_transfers_list_response
+    headers: response_headers,
+    body: '{
+      "_embedded": {
+         "balance_transfers": [
+            {
+               "balance_transfer_id": "07b5-46e1-a527-85530e625800",
+               "amount": 123.45,
+               "from": "7c9738e6",
+               "to": "abc123",
+               "created_at": "2019-03-02T16:34:49Z"
+            },
+            {
+              "balance_transfer_id": "07b5-46e1-a527-85530e625800",
+              "amount": 123.45,
+              "from": "7c9738e6",
+              "to": "def456",
+              "created_at": "2019-03-02T16:34:49Z"
+           }
+         ]
+      }
+   }'
+  end
+
+  def balance_transfers_list_response_filtered
+    headers: response_headers,
+    body: '{
+      "_embedded": {
+         "balance_transfers": [
+            {
+               "balance_transfer_id": "07b5-46e1-a527-85530e625800",
+               "amount": 123.45,
+               "from": "7c9738e6",
+               "to": "abc123",
+               "created_at": "2019-03-02T16:34:49Z"
+            }
+         ]
+      }
+   }'
+  end
+end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -91,10 +91,14 @@ class Vonage::SubaccountsTest < Vonage::Test
     credit_transfers_list.each { |credit_transfer| assert_kind_of Vonage::Entity, credit_transfer }
   end
 
-  def test_list_credit_transfers_method_without_start_date
-    assert_raises ArgumentError do
-      subaccounts.list_credit_transfers
-    end
+  def test_list_credit_transfers_method_without_start_date_uses_default
+    query = "?start_date=1970-01-01T00:00:00Z"
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response)
+
+    credit_transfers_list = subaccounts.list_credit_transfers
+
+    assert_kind_of Vonage::Subaccounts::CreditTransfers::ListResponse, credit_transfers_list
+    credit_transfers_list.each { |credit_transfer| assert_kind_of Vonage::Entity, credit_transfer }
   end
 
   def test_transfer_credit_method
@@ -147,10 +151,14 @@ class Vonage::SubaccountsTest < Vonage::Test
     balance_transfers_list.each { |balance_transfer| assert_kind_of Vonage::Entity, balance_transfer }
   end
 
-  def test_list_balance_transfers_method_without_start_date
-    assert_raises ArgumentError do
-      subaccounts.list_balance_transfers
-    end
+  def test_list_balance_transfers_method_without_start_date_uses_default
+    query = "?start_date=1970-01-01T00:00:00Z"
+    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response)
+
+    balance_transfers_list = subaccounts.list_balance_transfers
+
+    assert_kind_of Vonage::Subaccounts::BalanceTransfers::ListResponse, balance_transfers_list
+    balance_transfers_list.each { |balance_transfer| assert_kind_of Vonage::Entity, balance_transfer }
   end
 
   def test_transfer_balance_method

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -72,22 +72,29 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_credit_transfers_method
-    stub_request(:get, "#{accounts_uri}/credit-transfers").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response)
+    query = "?start_date=2023-06-15T15:53:50Z"
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response)
 
-    credit_transfers_list = subaccounts.list_credit_transfers
+    credit_transfers_list = subaccounts.list_credit_transfers(start_date: "2023-06-15T15:53:50Z")
 
     assert_kind_of Vonage::Subaccounts::CreditTransfers::ListResponse, credit_transfers_list
     credit_transfers_list.each { |credit_transfer| assert_kind_of Vonage::Entity, credit_transfer }
   end
 
   def test_list_credit_transfers_method_with_optional_params
-    query = "?subaccount=abc123"
+    query = "?start_date=2023-06-15T15:53:50Z&subaccount=abc123"
     stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response_filtered)
 
-    credit_transfers_list = subaccounts.list_credit_transfers(subaccount: 'abc123')
+    credit_transfers_list = subaccounts.list_credit_transfers(start_date: "2023-06-15T15:53:50Z", subaccount: 'abc123')
 
     assert_kind_of Vonage::Subaccounts::CreditTransfers::ListResponse, credit_transfers_list
     credit_transfers_list.each { |credit_transfer| assert_kind_of Vonage::Entity, credit_transfer }
+  end
+
+  def test_list_credit_transfers_method_without_start_date
+    assert_raises ArgumentError do
+      subaccounts.list_credit_transfers
+    end
   end
 
   def test_transfer_credit_method
@@ -121,22 +128,29 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_balance_transfers_method
-    stub_request(:get, "#{accounts_uri}/balance-transfers").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response)
+    query = "?start_date=2023-06-15T15:53:50Z"
+    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response)
 
-    balance_transfers_list = subaccounts.list_balance_transfers
+    balance_transfers_list = subaccounts.list_balance_transfers(start_date: "2023-06-15T15:53:50Z")
 
     assert_kind_of Vonage::Subaccounts::BalanceTransfers::ListResponse, balance_transfers_list
     balance_transfers_list.each { |balance_transfer| assert_kind_of Vonage::Entity, balance_transfer }
   end
 
   def test_list_balance_transfers_method_with_optional_params
-    query = "?subaccount=abc123"
+    query = "?start_date=2023-06-15T15:53:50Z&subaccount=abc123"
     stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response_filtered)
 
-    balance_transfers_list = subaccounts.list_balance_transfers(subaccount: 'abc123')
+    balance_transfers_list = subaccounts.list_balance_transfers(start_date: "2023-06-15T15:53:50Z", subaccount: 'abc123')
 
     assert_kind_of Vonage::Subaccounts::BalanceTransfers::ListResponse, balance_transfers_list
     balance_transfers_list.each { |balance_transfer| assert_kind_of Vonage::Entity, balance_transfer }
+  end
+
+  def test_list_balance_transfers_method_without_start_date
+    assert_raises ArgumentError do
+      subaccounts.list_balance_transfers
+    end
   end
 
   def test_transfer_balance_method
@@ -170,32 +184,32 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_number_method
-    stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696 }, auth: basic_authorization)).to_return(response)
-
-    assert_kind_of Vonage::Response, subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696)
-  end
-
-  def test_transfer_number_method_with_optional_params
     stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' }, auth: basic_authorization)).to_return(response)
 
-    assert_kind_of Vonage::Response, subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696, country: 'GB' )
+    assert_kind_of Vonage::Response, subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696, country: 'GB')
   end
 
   def test_transfer_number_method_without_from
     assert_raises ArgumentError do
-      subaccounts.transfer_number(to: "def456", number: 23507703696)
+      subaccounts.transfer_number(to: "def456", number: 23507703696, country: 'GB')
     end
   end
 
   def test_transfer_number_method_without_to
     assert_raises ArgumentError do
-      subaccounts.transfer_number(from: "abc123", number: 23507703696)
+      subaccounts.transfer_number(from: "abc123", number: 23507703696, country: 'GB')
     end
   end
 
-  def test_transfer_number_method_without_amount
+  def test_transfer_number_method_without_number
     assert_raises ArgumentError do
-      subaccounts.transfer_number(from: "abc123", to: "def456")
+      subaccounts.transfer_number(from: "abc123", to: "def456", country: 'GB')
+    end
+  end
+
+  def test_transfer_number_method_without_country
+    assert_raises ArgumentError do
+      subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696)
     end
   end
 

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -39,21 +39,18 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_create_method
-    skip
-    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo" })).to_return(response)
+    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo" }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.create(name: "Foo")
   end
 
   def test_create_method_with_optional_params
-    skip
-    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false })).to_return(response)
+    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false }, auth: basic_authorization)).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.create(name: "Foo", secret: "Password123", use_primary_account_balance: false)
   end
 
   def test_create_method_without_name
-    skip
     assert_raises ArgumentError do
       subaccounts.create
     end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -7,7 +7,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def accounts_uri
-    "https://rest.nexmo.com/accounts/#{api_key}"
+    "https://api.nexmo.com/accounts/#{api_key}"
   end
 
   def subaccounts_uri

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -216,114 +216,124 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def subaccounts_list_response
-    headers: response_headers,
-    body: '{
-      "_embedded": {
-         "primary_account": {
-            "api_key": "bbe6222f",
-            "name": "Subaccount department A",
-            "primary_account_api_key": "acc6111f",
-            "use_primary_account_balance": true,
-            "created_at": "2018-03-02T16:34:49Z",
-            "suspended": false,
-            "balance": 100.25,
-            "credit_limit": -100.25
-         },
-         "subaccounts": [
-            {
-               "api_key": "bbe6222f",
-               "name": "Subaccount department A",
-               "primary_account_api_key": "acc6111f",
-               "use_primary_account_balance": true,
-               "created_at": "2018-03-02T16:34:49Z",
-               "suspended": false,
-               "balance": 100.25,
-               "credit_limit": -100.25
-            }
-         ]
-      }
-   }'
+    {
+      headers: response_headers,
+      body: '{
+        "_embedded": {
+          "primary_account": {
+              "api_key": "bbe6222f",
+              "name": "Subaccount department A",
+              "primary_account_api_key": "acc6111f",
+              "use_primary_account_balance": true,
+              "created_at": "2018-03-02T16:34:49Z",
+              "suspended": false,
+              "balance": 100.25,
+              "credit_limit": -100.25
+          },
+          "subaccounts": [
+              {
+                "api_key": "bbe6222f",
+                "name": "Subaccount department A",
+                "primary_account_api_key": "acc6111f",
+                "use_primary_account_balance": true,
+                "created_at": "2018-03-02T16:34:49Z",
+                "suspended": false,
+                "balance": 100.25,
+                "credit_limit": -100.25
+              }
+            ]
+          }
+        }'
+        }
   end
 
   def credit_transfers_list_response
-    headers: response_headers,
-    body: '{
-      "_embedded": {
-         "credit-transfers": [
-            {
-               "credit_transfer_id": "07b5-46e1-a527-85530e625800",
-               "amount": 123.45,
-               "from": "7c9738e6",
-               "to": "abc123",
-               "created_at": "2019-03-02T16:34:49Z"
-            },
-            {
-              "credit_transfer_id": "07b5-46e1-a527-85530e625800",
-              "amount": 100.99,
-              "from": "def456",
-              "to": "ad6dc56f",
-              "created_at": "2019-03-02T16:34:49Z"
-           }
-         ]
-      }
-   }'
+    {
+      headers: response_headers,
+      body: '{
+        "_embedded": {
+          "credit-transfers": [
+              {
+                "credit_transfer_id": "07b5-46e1-a527-85530e625800",
+                "amount": 123.45,
+                "from": "7c9738e6",
+                "to": "abc123",
+                "created_at": "2019-03-02T16:34:49Z"
+              },
+              {
+                "credit_transfer_id": "07b5-46e1-a527-85530e625800",
+                "amount": 100.99,
+                "from": "def456",
+                "to": "ad6dc56f",
+                "created_at": "2019-03-02T16:34:49Z"
+              }
+            ]
+          }
+        }'
+    }
   end
 
   def credit_transfers_list_response_filtered
-    headers: response_headers,
-    body: '{
-      "_embedded": {
-         "credit-transfers": [
-            {
-               "credit_transfer_id": "07b5-46e1-a527-85530e625800",
-               "amount": 123.45,
-               "from": "7c9738e6",
-               "to": "abc123",
-               "created_at": "2019-03-02T16:34:49Z"
-            }
-         ]
-      }
-   }'
+    {
+     headers: response_headers,
+      body: '{
+        "_embedded": {
+          "credit-transfers": [
+              {
+                "credit_transfer_id": "07b5-46e1-a527-85530e625800",
+                "amount": 123.45,
+                "from": "7c9738e6",
+                "to": "abc123",
+                "created_at": "2019-03-02T16:34:49Z"
+              }
+            ]
+          }
+        }'
+    }
   end
 
   def balance_transfers_list_response
-    headers: response_headers,
-    body: '{
-      "_embedded": {
-         "balance_transfers": [
-            {
-               "balance_transfer_id": "07b5-46e1-a527-85530e625800",
-               "amount": 123.45,
-               "from": "7c9738e6",
-               "to": "abc123",
-               "created_at": "2019-03-02T16:34:49Z"
-            },
-            {
-              "balance_transfer_id": "07b5-46e1-a527-85530e625800",
-              "amount": 123.45,
-              "from": "7c9738e6",
-              "to": "def456",
-              "created_at": "2019-03-02T16:34:49Z"
-           }
-         ]
-      }
-   }'
+    {
+      headers: response_headers,
+      body: '{
+        "_embedded": {
+          "balance_transfers": [
+              {
+                "balance_transfer_id": "07b5-46e1-a527-85530e625800",
+                "amount": 123.45,
+                "from": "7c9738e6",
+                "to": "abc123",
+                "created_at": "2019-03-02T16:34:49Z"
+              },
+              {
+                "balance_transfer_id": "07b5-46e1-a527-85530e625800",
+                "amount": 123.45,
+                "from": "7c9738e6",
+                "to": "def456",
+                "created_at": "2019-03-02T16:34:49Z"
+              }
+            ]
+          }
+        }'
+    }
   end
 
   def balance_transfers_list_response_filtered
-    headers: response_headers,
-    body: '{
-      "_embedded": {
-         "balance_transfers": [
-            {
-               "balance_transfer_id": "07b5-46e1-a527-85530e625800",
-               "amount": 123.45,
-               "from": "7c9738e6",
-               "to": "abc123",
-               "created_at": "2019-03-02T16:34:49Z"
-            }
-         ]
-      }
-   }'
+    {
+      headers: response_headers,
+      body: '{
+        "_embedded": {
+          "balance_transfers": [
+              {
+                "balance_transfer_id": "07b5-46e1-a527-85530e625800",
+                "amount": 123.45,
+                "from": "7c9738e6",
+                "to": "abc123",
+                "created_at": "2019-03-02T16:34:49Z"
+              }
+            ]
+           }
+          }'
+    }
   end
 end

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -83,7 +83,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_credit_transfers_method_with_optional_params
     query = "?subaccount=abc123"
-    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").to_return(credit_transfers_list_response_filtered)
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response_filtered)
 
     credit_transfers_list = subaccounts.list_credit_transfers(subaccount: 'abc123')
 
@@ -122,8 +122,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_balance_transfers_method
-    skip
-    stub_request(:get, subaccounts_uri + "/balance-transfers").to_return(balance_transfers_list_response)
+    stub_request(:get, "#{accounts_uri}/balance-transfers").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response)
 
     balance_transfers_list = subaccounts.list_balance_transfers
 
@@ -132,9 +131,8 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_list_balance_transfers_method_with_optional_params
-    skip
     query = "?subaccount=abc123"
-    stub_request(:get, subaccounts_uri + "/balance-transfers" + query).to_return(balance_transfers_list_response_filtered)
+    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response_filtered)
 
     balance_transfers_list = subaccounts.list_balance_transfers(subaccount: 'abc123')
 

--- a/test/vonage/test.rb
+++ b/test/vonage/test.rb
@@ -87,8 +87,8 @@ module Vonage
       'Basic dm9uYWdlLWFwaS1rZXk6dm9uYWdlLWFwaS1zZWNyZXQ='
     end
 
-    def request(body: nil, query: nil, headers: {})
-      headers['Authorization'] = authorization
+    def request(body: nil, query: nil, headers: {}, auth: nil)
+      headers['Authorization'] = auth || authorization
       headers['Content-Type'] = 'application/json' if body
 
       {headers: headers, body: body, query: query}.compact


### PR DESCRIPTION
This PR adds functionality for the [Subaccounts API](https://developer.vonage.com/en/account/subaccounts/overview) to the SDK. Specifically, it does the following:

- Update the `Client` class to add a `subaccounts` method (which returns a `Subaccounts` object)
- Defines a `Subaccounts` object with the following methods:
  - `list`
  - `find`
  - `create`
  - `update`
  - `list_credit_transfers`
  - `transfer_credit`
  - `list_balance_transfers`
  - `transfer_balance`
  - `transfer_number`
- Additionally it:
  - Adds `ListResponse` classes for `list`, `list_credit_transfers`, and `list_balance_transfers`
  - Adds unit tests for the above functionality

