### PR TITLE
DEVX-7644: Update Meetings API Endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
-      run: bundle install --without development
+      run: bundle install
     - name: Run tests
       run: bundle exec rake test
       env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.15.1
+
+* Updates Meetings endpoints to `v1`. [#286](https://github.com/Vonage/vonage-ruby-sdk/pull/286)
+
 # 7.15.0
 
 * Adds Users. [#282](https://github.com/Vonage/vonage-ruby-sdk/pull/282)

--- a/lib/vonage/meetings/applications.rb
+++ b/lib/vonage/meetings/applications.rb
@@ -19,7 +19,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#updateApplication
     def update(default_theme_id:)
-      request("/meetings/applications", params: {update_details: {default_theme_id: default_theme_id}}, type: Patch)
+      request("/v1/meetings/applications", params: {update_details: {default_theme_id: default_theme_id}}, type: Patch)
     end
   end
 end

--- a/lib/vonage/meetings/dial_in_numbers.rb
+++ b/lib/vonage/meetings/dial_in_numbers.rb
@@ -17,7 +17,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getDialInNumbers
     def list
-      request("/meetings/dial-in-numbers", response_class: ListResponse)
+      request("/v1/meetings/dial-in-numbers", response_class: ListResponse)
     end
   end
 end

--- a/lib/vonage/meetings/recordings.rb
+++ b/lib/vonage/meetings/recordings.rb
@@ -19,7 +19,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getRecording
     def info(recording_id:)
-      request("/meetings/recordings/" + recording_id)
+      request("/v1/meetings/recordings/" + recording_id)
     end
 
     # Delete a specified recording.
@@ -30,7 +30,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#deleteRecording
     def delete(recording_id:)
-      request("/meetings/recordings/" + recording_id, type: Delete)
+      request("/v1/meetings/recordings/" + recording_id, type: Delete)
     end
   end
 end

--- a/lib/vonage/meetings/rooms.rb
+++ b/lib/vonage/meetings/rooms.rb
@@ -23,7 +23,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getRooms
     def list(**params)
-      path = "/meetings/rooms"
+      path = "/v1/meetings/rooms"
       path += "?#{Params.encode(params)}" unless params.empty?
 
       request(path, response_class: ListResponse)
@@ -38,7 +38,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getRoom
     def info(room_id:)
-      request("/meetings/rooms/" + room_id)
+      request("/v1/meetings/rooms/" + room_id)
     end
 
     # Create a new room.
@@ -96,7 +96,7 @@ module Vonage
     # @see https://developer.vonage.com/en/api/meetings#createRoom
     def create(display_name:, **params)
       request(
-        "/meetings/rooms",
+        "/v1/meetings/rooms",
         params: params.merge({ display_name: display_name }),
         type: Post
       )
@@ -144,7 +144,7 @@ module Vonage
     def update(room_id:, **params)
       raise ArgumentError, 'must provide at least one other param in addition to :room_id' if params.empty?
       request(
-        "/meetings/rooms/" + room_id,
+        "/v1/meetings/rooms/" + room_id,
         params: {
           update_details: params
         },

--- a/lib/vonage/meetings/sessions.rb
+++ b/lib/vonage/meetings/sessions.rb
@@ -20,7 +20,7 @@ module Vonage
     # @see https://developer.vonage.com/en/api/meetings#getSessionRecordings
     def list_recordings(session_id:)
       request(
-        "/meetings/sessions/" + session_id + "/recordings",
+        "/v1/meetings/sessions/" + session_id + "/recordings",
         response_class: ListResponse
       )
     end

--- a/lib/vonage/meetings/themes.rb
+++ b/lib/vonage/meetings/themes.rb
@@ -17,7 +17,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getThemes
     def list
-      request("/meetings/themes", response_class: ListResponse)
+      request("/v1/meetings/themes", response_class: ListResponse)
     end
 
     # Return information for specified theme.
@@ -28,7 +28,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getThemeById
     def info(theme_id:)
-      request("/meetings/themes/" + theme_id)
+      request("/v1/meetings/themes/" + theme_id)
     end
 
     # Create a new theme.
@@ -50,7 +50,7 @@ module Vonage
     # @see https://developer.vonage.com/en/api/meetings#createTheme
     def create(main_color:, brand_text:, **params)
       request(
-        "/meetings/themes",
+        "/v1/meetings/themes",
         params: params.merge(main_color: main_color, brand_text: brand_text),
         type: Post
       )
@@ -77,7 +77,7 @@ module Vonage
     # @see https://developer.vonage.com/en/api/meetings#updateTheme
     def update(theme_id:, **params)
       request(
-        "/meetings/themes/" + theme_id,
+        "/v1/meetings/themes/" + theme_id,
         params: {
           update_details: params
         },
@@ -97,7 +97,7 @@ module Vonage
     # @see https://developer.vonage.com/en/api/meetings#deleteTheme
     def delete(theme_id:, force: false)
       request(
-        "/meetings/themes/" + theme_id + "?force=#{force}",
+        "/v1/meetings/themes/" + theme_id + "?force=#{force}",
         type: Delete
       )
     end
@@ -116,7 +116,7 @@ module Vonage
     #
     # @see https://developer.vonage.com/en/api/meetings#getRoomsByThemeId
     def list_rooms(theme_id:, **params)
-      path = "/meetings/themes/" + theme_id + "/rooms"
+      path = "/v1/meetings/themes/" + theme_id + "/rooms"
       path += "?#{Params.encode(params)}" unless params.empty?
 
       request(path, response_class: Meetings::Rooms::ListResponse)
@@ -164,7 +164,7 @@ module Vonage
     private
 
     def get_logo_upload_credentials
-      request("/meetings/themes/logos-upload-urls", response_class: ListResponse)
+      request("/v1/meetings/themes/logos-upload-urls", response_class: ListResponse)
     end
 
     def upload_logo_file(filepath:, credentials:)
@@ -185,7 +185,7 @@ module Vonage
 
     def finalize_logos(theme_id:, keys: [])
       request(
-        "/meetings/themes/" + theme_id + "/finalizeLogos",
+        "/v1/meetings/themes/" + theme_id + "/finalizeLogos",
         params: {
           keys: keys
         },

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = "7.15.0"
+  VERSION = "7.15.1"
 end

--- a/test/vonage/meetings/applications_test.rb
+++ b/test/vonage/meetings/applications_test.rb
@@ -6,7 +6,7 @@ class Vonage::Meetings::ApplicationsTest < Vonage::Test
   end
 
   def applications_uri
-    "https://" + meetings_host + "/meetings/applications"
+    "https://" + meetings_host + "/v1/meetings/applications"
   end
 
   def test_update_method

--- a/test/vonage/meetings/dial_in_numbers_test.rb
+++ b/test/vonage/meetings/dial_in_numbers_test.rb
@@ -6,7 +6,7 @@ class Vonage::Meetings::DialInNumbersTest < Vonage::Test
   end
 
   def dial_in_numbers_uri
-    "https://" + meetings_host + "/meetings/dial-in-numbers"
+    "https://" + meetings_host + "/v1/meetings/dial-in-numbers"
   end
 
   def list_response

--- a/test/vonage/meetings/recordings_test.rb
+++ b/test/vonage/meetings/recordings_test.rb
@@ -6,7 +6,7 @@ class Vonage::Meetings::RecordingsTest < Vonage::Test
   end
 
   def recording_uri
-    "https://" + meetings_host + "/meetings/recordings/" + meetings_id
+    "https://" + meetings_host + "/v1/meetings/recordings/" + meetings_id
   end
 
   def test_info_method

--- a/test/vonage/meetings/rooms_test.rb
+++ b/test/vonage/meetings/rooms_test.rb
@@ -6,11 +6,11 @@ class Vonage::Meetings::RoomsTest < Vonage::Test
   end
 
   def rooms_uri
-    "https://" + meetings_host + "/meetings/rooms"
+    "https://" + meetings_host + "/v1/meetings/rooms"
   end
 
   def room_uri
-    "https://" + meetings_host + "/meetings/rooms/" + meetings_id
+    "https://" + meetings_host + "/v1/meetings/rooms/" + meetings_id
   end
 
   def test_list_method

--- a/test/vonage/meetings/sessions_test.rb
+++ b/test/vonage/meetings/sessions_test.rb
@@ -6,7 +6,7 @@ class Vonage::Meetings::SessionsTest < Vonage::Test
   end
 
   def sessions_uri
-    "https://" + meetings_host + "/meetings/sessions/" + meetings_id +
+    "https://" + meetings_host + "/v1/meetings/sessions/" + meetings_id +
       "/recordings"
   end
 

--- a/test/vonage/meetings/themes_test.rb
+++ b/test/vonage/meetings/themes_test.rb
@@ -6,11 +6,11 @@ class Vonage::Meetings::ThemesTest < Vonage::Test
   end
 
   def themes_uri
-    "https://" + meetings_host + "/meetings/themes"
+    "https://" + meetings_host + "/v1/meetings/themes"
   end
 
   def theme_uri
-    "https://" + meetings_host + "/meetings/themes/" + meetings_id
+    "https://" + meetings_host + "/v1/meetings/themes/" + meetings_id
   end
 
   def list_response


### PR DESCRIPTION
This PR:

Updates the endpoints for all the Meetings API methods and associated tests in order to prepend the paths for each endpoint with `/v1` (which is in line with the API spec).