### PR TITLE
DEVX-6461: Improving Exceptions for API Errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.16.0
+
+* Adds HTTP Response context to some Exception types. [#287](https://github.com/Vonage/vonage-ruby-sdk/pull/287)
+
 # 7.15.1
 
 * Updates Meetings endpoints to `v1`. [#286](https://github.com/Vonage/vonage-ruby-sdk/pull/286)

--- a/lib/vonage.rb
+++ b/lib/vonage.rb
@@ -7,6 +7,7 @@ module Vonage
   loader = Zeitwerk::Loader.new
   loader.tag = File.basename(__FILE__, '.rb')
   loader.inflector.inflect({
+    'api_error' => 'APIError',
     'dtmf' => 'DTMF',
     'gsm7' => 'GSM7',
     'http' => 'HTTP',

--- a/lib/vonage/api_error.rb
+++ b/lib/vonage/api_error.rb
@@ -1,0 +1,33 @@
+# typed: strong
+require "json"
+
+module Vonage
+  class APIError < Error
+    extend T::Sig
+
+    sig { returns(Net::HTTPResponse) }
+    attr_reader :http_response
+
+    sig { params(message: T.nilable(String), http_response: T.nilable(Net::HTTPResponse)).void }
+    def initialize(message = nil, http_response: nil)
+      super(message)
+      @http_response = http_response
+    end
+
+    def http_response_code
+      return nil unless http_response
+      http_response.code
+    end
+
+    def http_response_headers
+      return nil unless http_response
+      http_response.to_hash
+    end
+
+    def http_response_body
+      return nil unless http_response
+      return {} unless http_response.content_type && http_response.content_type.include?("json")
+      ::JSON.parse(http_response.body)
+    end
+  end
+end

--- a/lib/vonage/client_error.rb
+++ b/lib/vonage/client_error.rb
@@ -1,6 +1,6 @@
 # typed: strong
 
 module Vonage
-  class ClientError < Error
+  class ClientError < APIError
   end
 end

--- a/lib/vonage/server_error.rb
+++ b/lib/vonage/server_error.rb
@@ -1,6 +1,6 @@
 # typed: strong
 
 module Vonage
-  class ServerError < Error
+  class ServerError < APIError
   end
 end

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = "7.15.1"
+  VERSION = "7.16.0"
 end


### PR DESCRIPTION
This PR:

- Adds additional context to some exception types.
  - It creates a new exception type `Vonage::APIError` from which `Vonage::ClientError` and `Vonage::ServerError` now inherit.
  - When an exception resulting from an API response not in the `2xx`/`3xx` range, when the exception is raised the `Net::HTTPResponse` object is now made available as a property on the exception
  - Unit tests have been added/updated to cover the new functionality.