### PR TITLE
DEVX-7758: Remove Validation for Verify2 Locales

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 7.17.0
 
-* Adds new locales to Verify2. [#289](https://github.com/Vonage/vonage-ruby-sdk/pull/289)
+* Removes locale validation in Verify2 in order to support any new locales added to the API. [#289](https://github.com/Vonage/vonage-ruby-sdk/pull/289)
 
 # 7.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.17.0
+
+* Adds new locales to Verify2. [#289](https://github.com/Vonage/vonage-ruby-sdk/pull/289)
+
 # 7.16.0
 
 * Adds HTTP Response context to some Exception types. [#287](https://github.com/Vonage/vonage-ruby-sdk/pull/287)

--- a/lib/vonage/verify2/start_verification_options.rb
+++ b/lib/vonage/verify2/start_verification_options.rb
@@ -5,13 +5,6 @@ module Vonage
   class Verify2::StartVerificationOptions
     VALID_OPTS = [:locale, :channel_timeout, :client_ref, :code_length, :code, :fraud_check].freeze
 
-    VALID_LOCALES = [
-      "ar-xa", "cs-cz", "cy-gb", "de-de", "el-gr", "en-au", "en-gb", "en-in", "en-us", "es-es", "es-mx", "es-us",
-      "fi-fi", "fil-ph", "fr-ca", "fr-fr", "he-il", "hi-in", "hu-hu", "id-id", "is-is", "it-it", "ja-jp", "nb-no",
-      "nl-nl", "pl-pl", "pt-br", "pt-pt", "ro-ro", "ru-ru", "sv-se", "th-th", "tr-tr", "vi-vn", "yue-cn", "zh-cn",
-      "zh-tw"
-    ].freeze
-
     MIN_CHANNEL_TIMEOUT, MAX_CHANNEL_TIMEOUT = [60, 900]
 
     MIN_CODE_LENGTH, MAX_CODE_LENGTH = [4, 10]
@@ -25,10 +18,6 @@ module Vonage
     end
 
     def locale=(locale)
-      unless VALID_LOCALES.include?(locale)
-        raise ArgumentError, "Invalid 'locale' #{locale}. Please choose from the following #{VALID_LOCALES}"
-      end
-
       @locale = locale
     end
 

--- a/lib/vonage/verify2/start_verification_options.rb
+++ b/lib/vonage/verify2/start_verification_options.rb
@@ -6,21 +6,10 @@ module Vonage
     VALID_OPTS = [:locale, :channel_timeout, :client_ref, :code_length, :code, :fraud_check].freeze
 
     VALID_LOCALES = [
-      "de-de",
-      "en-gb",
-      "en-us",
-      "es-es",
-      "es-us",
-      "fr-fr",
-      "he-il",
-      "hi-in",
-      "id-id",
-      "it-it",
-      "ja-jp",
-      "pt-br",
-      "pt-pt",
-      "ru-ru",
-      "yue-cn"
+      "ar-xa", "cs-cz", "cy-gb", "de-de", "el-gr", "en-au", "en-gb", "en-in", "en-us", "es-es", "es-mx", "es-us",
+      "fi-fi", "fil-ph", "fr-ca", "fr-fr", "he-il", "hi-in", "hu-hu", "id-id", "is-is", "it-it", "ja-jp", "nb-no",
+      "nl-nl", "pl-pl", "pt-br", "pt-pt", "ro-ro", "ru-ru", "sv-se", "th-th", "tr-tr", "vi-vn", "yue-cn", "zh-cn",
+      "zh-tw"
     ].freeze
 
     MIN_CHANNEL_TIMEOUT, MAX_CHANNEL_TIMEOUT = [60, 900]

--- a/lib/vonage/verify2/start_verification_options.rb
+++ b/lib/vonage/verify2/start_verification_options.rb
@@ -6,8 +6,21 @@ module Vonage
     VALID_OPTS = [:locale, :channel_timeout, :client_ref, :code_length, :code, :fraud_check].freeze
 
     VALID_LOCALES = [
-      'en-us', 'en-gb', 'es-es', 'es-mx', 'es-us', 'it-it', 'fr-fr',
-      'de-de', 'ru-ru', 'hi-in', 'pt-br', 'pt-pt', 'id-id'
+      "de-de",
+      "en-gb",
+      "en-us",
+      "es-es",
+      "es-us",
+      "fr-fr",
+      "he-il",
+      "hi-in",
+      "id-id",
+      "it-it",
+      "ja-jp",
+      "pt-br",
+      "pt-pt",
+      "ru-ru",
+      "yue-cn"
     ].freeze
 
     MIN_CHANNEL_TIMEOUT, MAX_CHANNEL_TIMEOUT = [60, 900]

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = "7.16.0"
+  VERSION = "7.17.0"
 end

--- a/test/vonage/verify2/start_verification_options_test.rb
+++ b/test/vonage/verify2/start_verification_options_test.rb
@@ -16,13 +16,6 @@ class Vonage::Verify2::StartVerificationOptionsTest < Vonage::Test
     assert_equal 'en-gb', opts.instance_variable_get(:@locale)
   end
 
-  def test_locale_setter_method_with_invalid_arg
-    opts = options
-    assert_raises ArgumentError do
-      opts.locale = 'foo-bar'
-    end
-  end
-
   def test_channel_timeout_getter_method
     assert_nil options.channel_timeout
   end


### PR DESCRIPTION
Removes validation from the `Verify2::StartVerificationOptions#locale=` setter in order to enable the setting of any new locales that have been added to the API, or may be added in the future.