### PR TITLE
DEVX-7780: Update Logger Type Signatures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 7.16.1
 
-* Updates Sorbet type signatures for Logger creation and assignment. [#290](https://github.com/Vonage/vonage-ruby-sdk/pull/287)
+* Updates Sorbet type signatures for Logger creation and assignment. [#290](https://github.com/Vonage/vonage-ruby-sdk/pull/290)
 
 # 7.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.16.1
+
+* Updates Sorbet type signatures for Logger creation and assignment. [#290](https://github.com/Vonage/vonage-ruby-sdk/pull/287)
+
 # 7.16.0
 
 * Adds HTTP Response context to some Exception types. [#287](https://github.com/Vonage/vonage-ruby-sdk/pull/287)

--- a/lib/vonage/config.rb
+++ b/lib/vonage/config.rb
@@ -130,7 +130,11 @@ module Vonage
 
     # @return [Vonage::Logger]
     #
-    sig { params(logger: T.nilable(T.any(::Logger, Vonage::Logger))).returns(T.nilable(Vonage::Logger)) }
+    sig { params(logger: T.nilable(
+      defined?(ActiveSupport::BroadcastLogger) ?
+        T.any(::Logger, Vonage::Logger, ActiveSupport::BroadcastLogger)
+      : T.any(::Logger, Vonage::Logger)
+    )).returns(T.nilable(Vonage::Logger)) }
     def logger=(logger)
       @logger = T.let(Logger.new(logger), T.nilable(Vonage::Logger))
     end

--- a/lib/vonage/logger.rb
+++ b/lib/vonage/logger.rb
@@ -7,7 +7,11 @@ module Vonage
   class Logger
     extend T::Sig
 
-    sig { params(logger: T.nilable(T.any(::Logger, Vonage::Logger))).void }
+    sig { params(logger: T.nilable(
+      defined?(ActiveSupport::BroadcastLogger) ?
+        T.any(::Logger, Vonage::Logger, ActiveSupport::BroadcastLogger)
+      : T.any(::Logger, Vonage::Logger)
+    )).void }
     def initialize(logger)
       @logger = logger || ::Logger.new(nil)
     end

--- a/lib/vonage/logger.rb
+++ b/lib/vonage/logger.rb
@@ -24,8 +24,6 @@ module Vonage
 
     sig { params(request: T.any(Net::HTTP::Post, Net::HTTP::Get, Net::HTTP::Delete, Net::HTTP::Put, Net::HTTP::Patch)).void }
     def log_request_info(request)
-      @logger = T.let(@logger, T.nilable(T.any(::Logger, Vonage::Logger)))
-
       T.must(@logger).info do
         format('Vonage API request', {
           method: request.method,

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = "7.16.0"
+  VERSION = "7.16.1"
 end


### PR DESCRIPTION
This PR updates some Sorbet type signatures for `Logger` creation and assignment. The motivation for this change is that in Rails `7.1.0` a change has been made to `Rails.logger` so that it no longer inherits from Ruby's std lib `Logger` class. This means that `Rails.logger` in `7.1.0` is invalid according to the type signatures in the Vonage Ruby SDK. See [this issue](https://github.com/Vonage/vonage-ruby-sdk/issues/288) for more detail.

The specific fix is to update the type signatures for logger creation and assignment to conditionally allow Rails 7.1's `ActiveSupport::BroadcastLogger` as a type if it is defined. The signatures updated are:

- `Vonage::Config#logger=`
- `Vonage::Logger#initialize`

Thanks to @ohbarye for the detailed bug report and proposed fix.