### PR TITLE
DEVX-7707: Add Webhook Token Verification Functionality

### DIFF
--- a/lib/vonage/jwt.rb
+++ b/lib/vonage/jwt.rb
@@ -40,6 +40,19 @@ module Vonage
       @token = Vonage::JWTBuilder.new(payload).jwt.generate
     end
 
+    # Validate a JSON Web Token from a Vonage Webhook.
+    #
+    # Certain Vonage APIs include a JWT signed with a user's account signature secret in
+    # the Authorization header of Webhook requests. This method can be used to verify that those requests originate
+    # from the Vonage API.
+    #
+    # @param [String, required] :token The JWT from the Webhook's Authorization header
+    # @param [String, required] :signature_secret The account signature secret
+    #
+    # @return [Boolean] true, if the JWT is verified, false otherwise
+    #
+    # @see https://developer.vonage.com/en/getting-started/concepts/webhooks#decoding-signed-webhooks
+    #
     def self.verify_hs256_signature(token:, signature_secret:)
       verify_signature(token, signature_secret, 'HS256')
     end

--- a/lib/vonage/jwt.rb
+++ b/lib/vonage/jwt.rb
@@ -39,5 +39,9 @@ module Vonage
       payload[:private_key] = private_key if private_key && !payload[:private_key]
       @token = Vonage::JWTBuilder.new(payload).jwt.generate
     end
+
+    def self.verify_hs256_signature(token:, signature_secret:)
+      verify_signature(token, signature_secret, 'HS256')
+    end
   end
 end

--- a/lib/vonage/messaging.rb
+++ b/lib/vonage/messaging.rb
@@ -25,5 +25,9 @@ module Vonage
     def send(params)
       request('/v1/messages', params: params, type: Post)
     end
+
+    def verify_webhook_token(token:, signature_secret: @config.signature_secret)
+      JWT.verify_hs256_signature(token: token, signature_secret: signature_secret)
+    end
   end
 end

--- a/lib/vonage/messaging.rb
+++ b/lib/vonage/messaging.rb
@@ -26,6 +26,13 @@ module Vonage
       request('/v1/messages', params: params, type: Post)
     end
 
+    # Validate a JSON Web Token from a Messages API Webhook.
+    #
+    # @param [String, required] :token The JWT from the Webhook's Authorization header
+    # @param [String, optional] :signature_secret The account signature secret. Required, unless `signature_secret`
+    #   is set in `Config`
+    #
+    # @return [Boolean] true, if the JWT is verified, false otherwise
     def verify_webhook_token(token:, signature_secret: @config.signature_secret)
       JWT.verify_hs256_signature(token: token, signature_secret: signature_secret)
     end

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -91,11 +91,22 @@ module Vonage
       response
     end
 
+    def verify_webhook_sig(webhook_params:, signature_secret: @config.signature_secret, signature_method: @config.signature_method)
+      signature.check(webhook_params, signature_secret: signature_secret, signature_method: signature_method)
+    end
+
     private
 
     sig { params(text: String).returns(T::Boolean) }
     def unicode?(text)
       !Vonage::GSM7.encoded?(text)
+    end
+
+    # @return [Signature]
+    #
+    sig { returns(T.nilable(Vonage::Signature)) }
+    def signature
+      @signature ||= T.let(Signature.new(@config), T.nilable(Vonage::Signature))
     end
   end
 end

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -91,6 +91,15 @@ module Vonage
       response
     end
 
+    # Validate a Signature from an SMS API Webhook.
+    #
+    # @param [Hash, required] :webhook_params The parameters from the webhook request body
+    # @param [String, optional] :signature_secret The account signature secret. Required, unless `signature_secret`
+    #   is set in `Config`
+    # @param [String, optional] :signature_method The account signature method. Required, unless `signature_method`
+    #   is set in `Config`
+    #
+    # @return [Boolean] true, if the JWT is verified, false otherwise
     def verify_webhook_sig(webhook_params:, signature_secret: @config.signature_secret, signature_method: @config.signature_method)
       signature.check(webhook_params, signature_secret: signature_secret, signature_method: signature_method)
     end

--- a/lib/vonage/voice.rb
+++ b/lib/vonage/voice.rb
@@ -280,6 +280,13 @@ module Vonage
       @dtmf ||= DTMF.new(@config)
     end
 
+    # Validate a JSON Web Token from a Voice API Webhook.
+    #
+    # @param [String, required] :token The JWT from the Webhook's Authorization header
+    # @param [String, optional] :signature_secret The account signature secret. Required, unless `signature_secret`
+    #   is set in `Config`
+    #
+    # @return [Boolean] true, if the JWT is verified, false otherwise
     def verify_webhook_token(token:, signature_secret: @config.signature_secret)
       JWT.verify_hs256_signature(token: token, signature_secret: signature_secret)
     end

--- a/lib/vonage/voice.rb
+++ b/lib/vonage/voice.rb
@@ -279,5 +279,9 @@ module Vonage
     def dtmf
       @dtmf ||= DTMF.new(@config)
     end
+
+    def verify_webhook_token(token:, signature_secret: @config.signature_secret)
+      JWT.verify_hs256_signature(token: token, signature_secret: signature_secret)
+    end
   end
 end

--- a/test/vonage/jwt_test.rb
+++ b/test/vonage/jwt_test.rb
@@ -1,7 +1,7 @@
 # typed: false
 require_relative './test'
 
-class Vonage::JWTTest < Minitest::Test
+class Vonage::JWTTest < Vonage::Test
   def private_key
     @private_key ||= File.read('test/private_key.txt')
   end
@@ -110,5 +110,17 @@ class Vonage::JWTTest < Minitest::Test
     token = Vonage::JWT.generate(payload, private_key)
 
     assert token
+  end
+
+  def test_verify_hs256_signature_with_valid_secret
+    verification = Vonage::JWT.verify_hs256_signature(token: sample_webhook_token, signature_secret: sample_valid_signature_secret)
+
+    assert_equal(true, verification)
+  end
+
+  def test_verify_hs256_signature_with_invalid_secret
+    verification = Vonage::JWT.verify_hs256_signature(token: sample_webhook_token, signature_secret: sample_invalid_signature_secret)
+
+    assert_equal(false, verification)
   end
 end

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -22,7 +22,30 @@ class Vonage::MessagingTest < Vonage::Test
     stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
 
     message = Vonage::Messaging::Message.sms(message: "Hello world!")
-    
+
     assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
+  end
+
+  def test_verify_webhook_token_method_with_valid_secret_passed_in
+    verification = messaging.verify_webhook_token(token: sample_webhook_token, signature_secret: sample_valid_signature_secret)
+
+    assert_equal(true, verification)
+  end
+
+  def test_verify_webhook_token_method_with_valid_secret_in_config
+    config.signature_secret = sample_valid_signature_secret
+    verification = messaging.verify_webhook_token(token: sample_webhook_token)
+
+    assert_equal(true, verification)
+  end
+
+  def test_verify_webhook_token_method_with_invalid_secret
+    verification = messaging.verify_webhook_token(token: sample_webhook_token, signature_secret: sample_invalid_signature_secret)
+
+    assert_equal(false, verification)
+  end
+
+  def test_verify_webhook_token_method_with_no_token
+    assert_raises(ArgumentError) { messaging.verify_webhook_token }
   end
 end

--- a/test/vonage/sms_test.rb
+++ b/test/vonage/sms_test.rb
@@ -24,6 +24,19 @@ class Vonage::SMSTest < Vonage::Test
     }
   end
 
+  def signed_webhook_params
+    {
+      'message-timestamp' => '2013-11-21 15:27:30',
+      'messageId' => '020000001B0FE827',
+      'msisdn' => '14843472194',
+      'text' => 'Test again',
+      'timestamp' => '1385047698',
+      'to' => '13239877404',
+      'type' => 'text',
+      'sig' => 'd2e7b1dc968737c5998ad624e02f90b7'
+    }
+  end
+
   def test_send_method
     params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!'}
 
@@ -59,5 +72,15 @@ class Vonage::SMSTest < Vonage::Test
     sms.send(params)
 
     assert_includes io.string, 'WARN -- : Sending unicode text SMS without setting the type parameter'
+  end
+
+  def test_verify_webhook_sig_method
+    check = sms.verify_webhook_sig(
+      webhook_params: signed_webhook_params,
+      signature_secret: 'my_secret_key_for_testing',
+      signature_method: 'md5hash'
+    )
+
+    assert_equal(true, check)
   end
 end

--- a/test/vonage/test.rb
+++ b/test/vonage/test.rb
@@ -59,6 +59,18 @@ module Vonage
       )
     end
 
+    def sample_webhook_token
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1ODc0OTQ5NjIsImp0aSI6ImM1YmE4ZjI0LTFhMTQtNGMxMC1iZmRmLTNmYmU4Y2U1MTFiNSIsImlzcyI6IlZvbmFnZSIsInBheWxvYWRfaGFzaCI6ImQ2YzBlNzRiNTg1N2RmMjBlM2I3ZTUxYjMwYzBjMmE0MGVjNzNhNzc4NzliNmYwNzRkZGM3YTIzMTdkZDAzMWIiLCJhcGlfa2V5IjoiYTFiMmMzZCIsImFwcGxpY2F0aW9uX2lkIjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtMDEyMzQ1Njc4OWFiIn0.JQRKi1d0SQitmjPINfTWMpt3XZkGsLbD7EjCdXoNSbk"
+    end
+
+    def sample_valid_signature_secret
+      "ZYtdTtGV3BCFN7tWmOWr1md66XsquMggr4W2cTtXtcPgfnI0Xw"
+    end
+
+    def sample_invalid_signature_secret
+      "ZYtdTtGV3BCFN7tWmOWr1md66XsquMggr4W2cTtXtcPgf55555"
+    end
+
     def config
       @config ||=
         Vonage::Config.new.merge(

--- a/test/vonage/voice_test.rb
+++ b/test/vonage/voice_test.rb
@@ -144,4 +144,27 @@ class Vonage::VoiceTest < Vonage::Test
   def test_dtmf_method
     assert_kind_of Vonage::Voice::DTMF, calls.dtmf
   end
+
+  def test_verify_webhook_token_method_with_valid_secret_passed_in
+    verification = calls.verify_webhook_token(token: sample_webhook_token, signature_secret: sample_valid_signature_secret)
+
+    assert_equal(true, verification)
+  end
+
+  def test_verify_webhook_token_method_with_valid_secret_in_config
+    config.signature_secret = sample_valid_signature_secret
+    verification = calls.verify_webhook_token(token: sample_webhook_token)
+
+    assert_equal(true, verification)
+  end
+
+  def test_verify_webhook_token_method_with_invalid_secret
+    verification = calls.verify_webhook_token(token: sample_webhook_token, signature_secret: sample_invalid_signature_secret)
+
+    assert_equal(false, verification)
+  end
+
+  def test_verify_webhook_token_method_with_no_token
+    assert_raises(ArgumentError) { calls.verify_webhook_token }
+  end
 end

--- a/vonage.gemspec
+++ b/vonage.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'This is the Ruby Server SDK for Vonage APIs. To use it you\'ll need a Vonage account. Sign up for free at https://www.vonage.com'
   s.files = Dir.glob('lib/**/*.rb') + %w(LICENSE.txt README.md vonage.gemspec)
   s.required_ruby_version = '>= 2.5.0'
-  s.add_dependency('vonage-jwt', '~> 0.1.3')
+  s.add_dependency('vonage-jwt', '~> 0.2.0')
   s.add_dependency('zeitwerk', '~> 2', '>= 2.2')
   s.add_dependency('sorbet-runtime', '~> 0.5')
   s.add_dependency('multipart-post', '~> 2.0')


### PR DESCRIPTION
This PR adds functionality to the SDK to verify JWTs included in Vonage webhooks. Specifically it:

- Updates the `gemspec` dependency for `vonage-jwt` to the new package
- Adds an SDK-specific `verify_hs256_signature` method to the `Vonage::JWT` class
- Adds `verify_webhook_token` wrapper methods to `Voice` and `Messaging` 
- Adds a `verify_webhook_sig` wrapper method to `SMS`
- Adds tests for the new functionality
- Updates the `README` to explain the new functionality