### PR TITLE
DEVX-7324: Add Number Insight v2

### DIFF
--- a/lib/vonage/client.rb
+++ b/lib/vonage/client.rb
@@ -89,6 +89,13 @@ module Vonage
       @number_insight ||= T.let(NumberInsight.new(config), T.nilable(Vonage::NumberInsight))
     end
 
+    # @return [NumberInsight2]
+    #
+    sig { returns(T.nilable(Vonage::NumberInsight2)) }
+    def number_insight_2
+      @number_insight_2 ||= T.let(NumberInsight2.new(config), T.nilable(Vonage::NumberInsight2))
+    end
+
     # @return [Numbers]
     #
     sig { returns(T.nilable(Vonage::Numbers)) }

--- a/lib/vonage/number_insight_2.rb
+++ b/lib/vonage/number_insight_2.rb
@@ -1,0 +1,36 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Vonage
+  class NumberInsight2 < Namespace
+    extend T::Sig
+
+    self.authentication = Basic
+
+    self.request_body = JSON
+
+    # Make fraud check requests with a phone number by looking up fraud score and/or by checking sim swap status.
+    #
+    # @example
+    #   response = client.number_insight_2.fraud_check(type: 'phone', phone: '447900000000', insights: ['fraud_score'])
+    #
+    # @param [required, String] :type The type of number to check.
+    #   Accepted value is “phone” when a phone number is provided.
+    #
+    # @param [required, String] :phone A single phone number that you need insight about in the E.164 format.
+    #
+    # @param [required, Array] :insights An array of strings indicating the fraud check insights required for the number.
+    #   Must be least one of: `fraud_score`, `sim_swap`
+    #
+    # @return [Response]
+    #
+    # @see https://developer.vonage.com/en/api/number-insight.v2#fraud_check
+    #
+    sig { params(type: String, phone: String, insights: T::Array[String]).returns(Vonage::Response) }
+    def fraud_check(type:, phone:, insights:)
+      raise ArgumentError.new("`insights` must not be an empty") if insights.empty?
+
+      request('/v2/ni', params: {type: type, phone: phone, insights: insights}, type: Post)
+    end
+  end
+end

--- a/lib/vonage/verify2.rb
+++ b/lib/vonage/verify2.rb
@@ -10,7 +10,7 @@ module Vonage
     # Request a verification be sent to a user.
     #
     # @example
-    #   verification_request = verify.start_verification(
+    #   verification_request = client.verify2.start_verification(
     #     brand: 'Acme',
     #     workflow: [{channel: 'sms', to: '447000000000'}],
     #     code_length: 6
@@ -41,7 +41,7 @@ module Vonage
     # Check a supplied code against a request to see if it is valid.
     #
     # @example
-    #   code_check = verify.check_code(request_id: '7e8c5965-0a3f-44df-8a14-f1486209d8a2', code: '1234')
+    #   code_check = client.verify2.check_code(request_id: '7e8c5965-0a3f-44df-8a14-f1486209d8a2', code: '1234')
     #
     # @param [required, String] :request_id The request_id of the verification request being checked
     #
@@ -56,7 +56,7 @@ module Vonage
     # Cancel a verifiction. If a verification request is still active, calling this method aborts the workflow.
     #
     # @example
-    #   verify.cancel_verification_request(request_id: '7e8c5965-0a3f-44df-8a14-f1486209d8a2')
+    #   client.verify2.cancel_verification_request(request_id: '7e8c5965-0a3f-44df-8a14-f1486209d8a2')
     #
     # @param [required, String] :request_id The request_id of the verification request to be cancelled
     #

--- a/test/vonage/client_test.rb
+++ b/test/vonage/client_test.rb
@@ -54,6 +54,10 @@ class Vonage::ClientTest < Vonage::Test
     assert_kind_of Vonage::NumberInsight, client.number_insight
   end
 
+  def test_number_insight_2_method
+    assert_kind_of Vonage::NumberInsight2, client.number_insight_2
+  end
+
   def test_numbers_method
     assert_kind_of Vonage::Numbers, client.numbers
   end

--- a/test/vonage/number_insight_2_test.rb
+++ b/test/vonage/number_insight_2_test.rb
@@ -1,0 +1,63 @@
+# typed: false
+require_relative './test'
+
+class Vonage::NumberInsight2Test < Vonage::Test
+  def number_insight_2
+    Vonage::NumberInsight2.new(config)
+  end
+
+  def uri
+    'https://api.nexmo.com/v2/ni'
+  end
+
+  def number
+    '447700900000'
+  end
+
+  def test_fraud_check_method
+    params = {type: 'phone', phone: number, insights: ['fraud_score', 'sim_swap']}
+    stub_request(:post, uri).with(body: params).to_return(response)
+
+    assert_kind_of Vonage::Response, number_insight_2.fraud_check(**params)
+  end
+
+  def test_fraud_check_method_without_type
+    params = {phone: number, insights: ['fraud_score', 'sim_swap']}
+
+    assert_raises ArgumentError do
+      number_insight_2.fraud_check(**params)
+    end
+  end
+
+  def test_fraud_check_method_without_phone
+    params = {type: 'phone', insights: ['fraud_score', 'sim_swap']}
+
+    assert_raises ArgumentError do
+      number_insight_2.fraud_check(**params)
+    end
+  end
+
+  def test_fraud_check_method_without_insights
+    params = {type: 'phone', phone: number}
+
+    assert_raises ArgumentError do
+      number_insight_2.fraud_check(**params)
+    end
+  end
+
+  def test_fraud_check_method_with_insights_not_an_array
+    params = {type: 'phone', phone: number, insights: 'fraud_score'}
+
+    assert_raises TypeError do
+      number_insight_2.fraud_check(**params)
+    end
+  end
+
+  def test_fraud_check_method_with_insights_an_empty_array
+    params = {type: 'phone', phone: number, insights: []}
+
+    assert_raises ArgumentError do
+      number_insight_2.fraud_check(**params)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds [Number Insight v2](https://developer.vonage.com/en/number-insight/number-insight-v2/overview) functionality to the SDK. Specifically it:

- Defines a `NumberInsight2` class with 1 method:
  - `fraud_check`. This method initiates a fraud check for a specific number via the `/vs/ni` endpoint
- Defines a `number_insight_2` method in the `Client` class which returns a `NumberInsight2` object
- Adds unit tests to cover the above changes