### PR TITLE
DEVX-7907: Update Verify2 Silent Authentication workflow options

### DIFF
--- a/lib/vonage/verify2/channels/email.rb
+++ b/lib/vonage/verify2/channels/email.rb
@@ -10,16 +10,14 @@ module Vonage
     def initialize(to:, from: nil)
       self.channel = 'email'
       self.to = to
-      self.from = from if from
+      self.from = from unless from.nil?
     end
 
     def to=(to)
-      # TODO: add validation
       @to = to
     end
 
     def from=(from)
-      # TODO: add validation
       @from = from
     end
 

--- a/lib/vonage/verify2/channels/silent_auth.rb
+++ b/lib/vonage/verify2/channels/silent_auth.rb
@@ -5,16 +5,24 @@ require 'phonelib'
 module Vonage
   class Verify2::Channels::SilentAuth
 
-    attr_reader :channel, :to
+    attr_reader :channel, :to, :sandbox
+    attr_accessor :redirect_url
 
-    def initialize(to:)
+    def initialize(to:, redirect_url: nil, sandbox: false)
       self.channel = 'silent_auth'
       self.to = to
+      self.redirect_url = redirect_url if redirect_url
+      self.sandbox = sandbox
     end
 
     def to=(to)
       raise ArgumentError, "Invalid 'to' value #{to}. Expected to be in E.164 format" unless Phonelib.parse(to.to_i).valid?
       @to = to
+    end
+
+    def sandbox=(sandbox)
+      raise ArgumentError, "Invalid 'sandbox' value #{sandbox}. Expected to be boolean value" unless [true, false].include? sandbox
+      @sandbox = sandbox
     end
 
     def to_h

--- a/lib/vonage/verify2/channels/silent_auth.rb
+++ b/lib/vonage/verify2/channels/silent_auth.rb
@@ -1,23 +1,28 @@
 # typed: true
 # frozen_string_literal: true
 require 'phonelib'
+require 'uri'
 
 module Vonage
   class Verify2::Channels::SilentAuth
 
-    attr_reader :channel, :to, :sandbox
-    attr_accessor :redirect_url
+    attr_reader :channel, :to, :sandbox, :redirect_url
 
-    def initialize(to:, redirect_url: nil, sandbox: false)
+    def initialize(to:, redirect_url: nil, sandbox: nil)
       self.channel = 'silent_auth'
       self.to = to
-      self.redirect_url = redirect_url if redirect_url
-      self.sandbox = sandbox
+      self.redirect_url = redirect_url unless redirect_url.nil?
+      self.sandbox = sandbox unless sandbox.nil?
     end
 
     def to=(to)
       raise ArgumentError, "Invalid 'to' value #{to}. Expected to be in E.164 format" unless Phonelib.parse(to.to_i).valid?
       @to = to
+    end
+
+    def redirect_url=(redirect_url)
+      raise ArgumentError, "Invalid 'to' value #{redirect_url}. Expected to be a valid URL" unless URI.parse(redirect_url).is_a?(URI::HTTP)
+      @redirect_url = redirect_url
     end
 
     def sandbox=(sandbox)

--- a/lib/vonage/verify2/channels/sms.rb
+++ b/lib/vonage/verify2/channels/sms.rb
@@ -11,7 +11,7 @@ module Vonage
     def initialize(to:, app_hash: nil)
       self.channel = 'sms'
       self.to = to
-      self.app_hash = app_hash if app_hash
+      self.app_hash = app_hash unless app_hash.nil?
     end
 
     def to=(to)

--- a/lib/vonage/verify2/channels/whats_app.rb
+++ b/lib/vonage/verify2/channels/whats_app.rb
@@ -10,7 +10,7 @@ module Vonage
     def initialize(to:, from: nil)
       self.channel = 'whatsapp'
       self.to = to
-      self.from = from if from
+      self.from = from unless from.nil?
     end
 
     def to=(to)

--- a/test/vonage/verify2/channels/silent_auth_test.rb
+++ b/test/vonage/verify2/channels/silent_auth_test.rb
@@ -35,6 +35,15 @@ class Vonage::Verify2::Channels::SilentAuthTest < Vonage::Test
     assert_equal test_url, sa_workflow.instance_variable_get(:@redirect_url)
   end
 
+  def test_redirect_url_setter_method_with_invalid_url
+    sa_workflow = silent_auth_channel
+    test_url = 'acme-app.com/sa/redirect'
+
+    assert_raises ArgumentError do
+      sa_workflow.redirect_url = test_url
+    end
+  end
+
   def test_redirect_url_getter_method
     sa_workflow = silent_auth_channel
     test_url = 'https://acme-app.com/sa/redirect'

--- a/test/vonage/verify2/channels/silent_auth_test.rb
+++ b/test/vonage/verify2/channels/silent_auth_test.rb
@@ -9,22 +9,60 @@ class Vonage::Verify2::Channels::SilentAuthTest < Vonage::Test
     assert_equal 'silent_auth', silent_auth_channel.channel
   end
 
-  def test_to_getter_method
-    assert_equal e164_compliant_number, silent_auth_channel.to
-  end
-
   def test_to_setter_method
-    channel = silent_auth_channel
+    sa_workflow = silent_auth_channel
     new_number = '447000000001'
-    channel.to = new_number
+    sa_workflow.to = new_number
 
-    assert_equal new_number, channel.instance_variable_get(:@to)
+    assert_equal new_number, sa_workflow.instance_variable_get(:@to)
   end
 
   def test_to_setter_method_with_invalid_number
     assert_raises ArgumentError do
       silent_auth_channel.to = invalid_number
     end
+  end
+
+  def test_to_getter_method
+    assert_equal e164_compliant_number, silent_auth_channel.to
+  end
+
+  def test_redirect_url_setter_method
+    sa_workflow = silent_auth_channel
+    test_url = 'https://acme-app.com/sa/redirect'
+    sa_workflow.redirect_url = test_url
+
+    assert_equal test_url, sa_workflow.instance_variable_get(:@redirect_url)
+  end
+
+  def test_redirect_url_getter_method
+    sa_workflow = silent_auth_channel
+    test_url = 'https://acme-app.com/sa/redirect'
+    sa_workflow.redirect_url = test_url
+
+    assert_equal test_url, sa_workflow.redirect_url
+  end
+
+  def test_sandbox_setter_method
+    sa_workflow = silent_auth_channel
+    sa_workflow.sandbox = true
+
+    assert_equal true, sa_workflow.instance_variable_get(:@sandbox)
+  end
+
+  def test_sandbox_setter_method_with_invalid_arg
+    sa_workflow = silent_auth_channel
+
+    assert_raises ArgumentError do
+      sa_workflow.sandbox = 'true'
+    end
+  end
+
+  def test_sandbox_getter_method
+    sa_workflow = silent_auth_channel
+    sa_workflow.sandbox = true
+
+    assert_equal true, sa_workflow.sandbox
   end
 
   def test_to_h_method


### PR DESCRIPTION
This PR updates the available options for a Verify v2 Silent Authentication workflow. Specifically it:

- Updates `Verify2::Channels::SilentAuth`:
  - Sets `redirect_url` and `sandbox` ivars in `#initialize`
  - Defines custom setter methods for the two new ivars (with input validation)
  - Defines getter methods for the two new ivars (via `attr_reader`)
- Adds/updates tests for the above implemention
- Some additional refactoring/ improvements for other channels