### PR TITLE
DEVX-8065/DEVX-7991: Verify2 SMS Updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.20.0
+
+* Updates Verify v2 API SMS channel to add new parameters. [#303](https://github.com/Vonage/vonage-ruby-sdk/pull/303)
+
 # 7.19.0
 
 * Adds Video API functionality. [#297](https://github.com/Vonage/vonage-ruby-sdk/pull/297)

--- a/lib/vonage/verify2/channels/sms.rb
+++ b/lib/vonage/verify2/channels/sms.rb
@@ -6,7 +6,7 @@ module Vonage
   class Verify2::Channels::SMS
     APP_HASH_LENGTH = 11
 
-    attr_reader :channel, :to, :from, :app_hash
+    attr_reader :channel, :to, :from, :entity_id, :content_id, :app_hash
 
     def initialize(to:, app_hash: nil)
       self.channel = 'sms'
@@ -22,6 +22,16 @@ module Vonage
     def from=(from)
       raise ArgumentError, "Invalid 'from' value #{from}. Expected to be in E.164 format" unless Phonelib.parse(from).valid?
       @from = from
+    end
+
+    def entity_id=(entity_id)
+      raise ArgumentError, "Invalid 'entity_id' value #{entity_id}. Length must be between 1 and 20 characters." unless entity_id.length.between?(1, 20)
+      @entity_id = entity_id
+    end
+
+    def content_id=(content_id)
+      raise ArgumentError, "Invalid 'content_id' value #{content_id}. Length must be between 1 and 20 characters ." unless content_id.length.between?(1, 20)
+      @content_id = content_id
     end
 
     def app_hash=(app_hash)

--- a/lib/vonage/verify2/channels/sms.rb
+++ b/lib/vonage/verify2/channels/sms.rb
@@ -20,7 +20,6 @@ module Vonage
     end
 
     def from=(from)
-      raise ArgumentError, "Invalid 'from' value #{from}. Expected to be in E.164 format" unless Phonelib.parse(from).valid?
       @from = from
     end
 

--- a/lib/vonage/verify2/channels/sms.rb
+++ b/lib/vonage/verify2/channels/sms.rb
@@ -6,7 +6,7 @@ module Vonage
   class Verify2::Channels::SMS
     APP_HASH_LENGTH = 11
 
-    attr_reader :channel, :to, :app_hash
+    attr_reader :channel, :to, :from, :app_hash
 
     def initialize(to:, app_hash: nil)
       self.channel = 'sms'
@@ -17,6 +17,11 @@ module Vonage
     def to=(to)
       raise ArgumentError, "Invalid 'to' value #{to}. Expected to be in E.164 format" unless Phonelib.parse(to).valid?
       @to = to
+    end
+
+    def from=(from)
+      raise ArgumentError, "Invalid 'from' value #{from}. Expected to be in E.164 format" unless Phonelib.parse(from).valid?
+      @from = from
     end
 
     def app_hash=(app_hash)

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.19.0'
+  VERSION = '7.20.0'
 end

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -60,6 +60,18 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     assert_equal '1101407360000017170', channel.instance_variable_get(:@entity_id)
   end
 
+  def test_entity_id_setter_method_with_invalid_arg_too_short
+    assert_raises ArgumentError do
+      sms_channel.entity_id = ''
+    end
+  end
+
+  def test_entity_id_setter_method_with_invalid_arg_too_long
+    assert_raises ArgumentError do
+      sms_channel.entity_id = '110140736000001717072'
+    end
+  end
+
   def test_content_id_getter_method
     assert_nil sms_channel.content_id
   end
@@ -69,6 +81,18 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     channel.content_id = '1101407360000017170'
 
     assert_equal '1101407360000017170', channel.instance_variable_get(:@content_id)
+  end
+
+  def test_content_id_setter_method_with_invalid_arg_too_short
+    assert_raises ArgumentError do
+      sms_channel.content_id = ''
+    end
+  end
+
+  def test_content_id_setter_method_with_invalid_arg_too_long
+    assert_raises ArgumentError do
+      sms_channel.content_id = '110140736000001717072'
+    end
   end
 
   def test_app_hash_getter_method

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -31,6 +31,24 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     end
   end
 
+  def test_from_getter_method
+    assert_nil sms_channel.from
+  end
+
+  def test_from_setter_method
+    channel = sms_channel
+    new_number = '447000000002'
+    channel.from = new_number
+
+    assert_equal new_number, channel.instance_variable_get(:@to)
+  end
+
+  def test_from_setter_method_with_invalid_number
+    assert_raises ArgumentError do
+      sms_channel.from = invalid_number
+    end
+  end
+
   def test_app_hash_getter_method
     assert_nil sms_channel.app_hash
   end

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -43,12 +43,6 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     assert_equal new_number, channel.instance_variable_get(:@from)
   end
 
-  def test_from_setter_method_with_invalid_number
-    assert_raises ArgumentError do
-      sms_channel.from = invalid_number
-    end
-  end
-
   def test_entity_id_getter_method
     assert_nil sms_channel.entity_id
   end

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -40,7 +40,7 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     new_number = '447000000002'
     channel.from = new_number
 
-    assert_equal new_number, channel.instance_variable_get(:@to)
+    assert_equal new_number, channel.instance_variable_get(:@from)
   end
 
   def test_from_setter_method_with_invalid_number

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -49,6 +49,28 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     end
   end
 
+  def test_entity_id_getter_method
+    assert_nil sms_channel.entity_id
+  end
+
+  def test_entity_id_setter_method
+    channel = sms_channel
+    channel.entity_id = '1101407360000017170'
+
+    assert_equal '1101407360000017170', channel.instance_variable_get(:@entity_id)
+  end
+
+  def test_content_id_getter_method
+    assert_nil sms_channel.content_id
+  end
+
+  def test_content_id_setter_method
+    channel = sms_channel
+    channel.content_id = '1101407360000017170'
+
+    assert_equal '1101407360000017170', channel.instance_variable_get(:@content_id)
+  end
+
   def test_app_hash_getter_method
     assert_nil sms_channel.app_hash
   end


### PR DESCRIPTION
This PR adds some properties to the SMS channel object for `Verify2`. Specifically it:

- Adds a `from` property
- Adds a `content_id` property
- Adds a `entity_id` property
- Adds unit tests for the new properties