### PR TITLE
DEVX-8152/DEVX-8189: Verify v2 Updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.23.0
+
+* Minor updates to Verify v2. [#306](https://github.com/Vonage/vonage-ruby-sdk/pull/306)
+
 # 7.22.0
 
 * Adds support for v1 the Conversation API. [#305](https://github.com/Vonage/vonage-ruby-sdk/pull/305)

--- a/lib/vonage/verify2.rb
+++ b/lib/vonage/verify2.rb
@@ -66,6 +66,10 @@ module Vonage
       request('/v2/verify/' + request_id, type: Delete)
     end
 
+    def next_workflow(request_id:)
+      request('/v2/verify/' + request_id + '/next-workflow', type: Post)
+    end
+
     # Instantiate a new Vonage::Verify2::StartVerificationOptions object
     #
     # @param [optional, Hash] opts the options for the verification request.

--- a/lib/vonage/verify2/channels/whats_app.rb
+++ b/lib/vonage/verify2/channels/whats_app.rb
@@ -7,10 +7,10 @@ module Vonage
 
     attr_reader :channel, :to, :from
 
-    def initialize(to:, from: nil)
+    def initialize(to:, from:)
       self.channel = 'whatsapp'
       self.to = to
-      self.from = from unless from.nil?
+      self.from = from
     end
 
     def to=(to)

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.22.0'
+  VERSION = '7.23.0'
 end

--- a/test/vonage/verify2/channels/email_test.rb
+++ b/test/vonage/verify2/channels/email_test.rb
@@ -9,8 +9,12 @@ class Vonage::Verify2::Channels::EmailTest < Vonage::Test
     'alice@example.com'
   end
 
-  def channel_getter_method
-    assert_equal 'whatsapp', email_channel.channel
+  def test_channel_getter_method
+    assert_equal 'email', email_channel.channel
+  end
+
+  def test_with_to_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::Email.new }
   end
 
   def test_to_getter_method

--- a/test/vonage/verify2/channels/silent_auth_test.rb
+++ b/test/vonage/verify2/channels/silent_auth_test.rb
@@ -5,8 +5,12 @@ class Vonage::Verify2::Channels::SilentAuthTest < Vonage::Test
     Vonage::Verify2::Channels::SilentAuth.new(to: e164_compliant_number)
   end
 
-  def channel_getter_method
+  def test_channel_getter_method
     assert_equal 'silent_auth', silent_auth_channel.channel
+  end
+
+  def test_with_to_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::SilentAuth.new }
   end
 
   def test_to_setter_method

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -9,8 +9,12 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     'FA+9qCX9VSu'
   end
 
-  def channel_getter_method
+  def test_channel_getter_method
     assert_equal 'sms', sms_channel.channel
+  end
+
+  def test_with_to_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::SMS.new }
   end
 
   def test_to_getter_method

--- a/test/vonage/verify2/channels/voice_test.rb
+++ b/test/vonage/verify2/channels/voice_test.rb
@@ -5,8 +5,12 @@ class Vonage::Verify2::Channels::VoiceTest < Vonage::Test
     Vonage::Verify2::Channels::Voice.new(to: e164_compliant_number)
   end
 
-  def channel_getter_method
+  def test_channel_getter_method
     assert_equal 'voice', voice_channel.channel
+  end
+
+  def test_with_to_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::Voice.new }
   end
 
   def test_to_getter_method

--- a/test/vonage/verify2/channels/whats_app_interactive_test.rb
+++ b/test/vonage/verify2/channels/whats_app_interactive_test.rb
@@ -5,8 +5,12 @@ class Vonage::Verify2::Channels::WhatsAppInteractiveTest < Vonage::Test
     Vonage::Verify2::Channels::WhatsAppInteractive.new(to: e164_compliant_number)
   end
 
-  def channel_getter_method
+  def test_channel_getter_method
     assert_equal 'whatsapp_interactive', whatsapp_interactive_channel.channel
+  end
+
+  def test_with_to_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::WhatsAppInteractive.new }
   end
 
   def test_to_getter_method

--- a/test/vonage/verify2/channels/whats_app_test.rb
+++ b/test/vonage/verify2/channels/whats_app_test.rb
@@ -2,11 +2,19 @@
 
 class Vonage::Verify2::Channels::WhatsAppTest < Vonage::Test
   def whatsapp_channel
-    Vonage::Verify2::Channels::WhatsApp.new(to: e164_compliant_number)
+    Vonage::Verify2::Channels::WhatsApp.new(to: e164_compliant_number, from: e164_compliant_number)
   end
 
-  def channel_getter_method
+  def test_channel_getter_method
     assert_equal 'whatsapp', whatsapp_channel.channel
+  end
+
+  def test_with_to_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::WhatsApp.new(from: e164_compliant_number) }
+  end
+
+  def test_with_from_omitted
+    assert_raises(ArgumentError) { Vonage::Verify2::Channels::WhatsApp.new(to: e164_compliant_number) }
   end
 
   def test_to_getter_method
@@ -28,17 +36,18 @@ class Vonage::Verify2::Channels::WhatsAppTest < Vonage::Test
   end
 
   def test_from_getter_method
-    assert_nil whatsapp_channel.from
+    assert_equal e164_compliant_number, whatsapp_channel.from
   end
 
   def test_from_setter_method
     channel = whatsapp_channel
-    channel.from = e164_compliant_number
+    new_number = '447000000001'
+    channel.from = new_number
 
-    assert_equal e164_compliant_number, channel.instance_variable_get(:@from)
+    assert_equal new_number, channel.instance_variable_get(:@from)
   end
 
-  def test_from_setter_method_with_invalid_arg
+  def test_from_setter_method_with_invalid_number
     assert_raises ArgumentError do
       whatsapp_channel.from = invalid_number
     end

--- a/test/vonage/verify2/workflow_builder_test.rb
+++ b/test/vonage/verify2/workflow_builder_test.rb
@@ -24,12 +24,12 @@ class Vonage::Verify2::WorkflowTest < Vonage::Test
   def test_build_method_adding_multiple_channels
     workflow = Vonage::Verify2::WorkflowBuilder.build do |builder|
       builder.add_sms(to: e164_compliant_number)
-      builder.add_whatsapp(to: e164_compliant_number)
+      builder.add_whatsapp(to: e164_compliant_number, from: e164_compliant_number)
     end
 
     assert_instance_of Vonage::Verify2::Workflow, workflow
     assert_instance_of Vonage::Verify2::Channels::SMS, workflow.list.first
     assert_instance_of Vonage::Verify2::Channels::WhatsApp, workflow.list.last
-    assert_equal({channel: 'whatsapp', to: e164_compliant_number}, workflow.list.last.to_h)
+    assert_equal({channel: 'whatsapp', to: e164_compliant_number, from: e164_compliant_number}, workflow.list.last.to_h)
   end
 end

--- a/test/vonage/verify2/workflow_test.rb
+++ b/test/vonage/verify2/workflow_test.rb
@@ -40,7 +40,7 @@ class Vonage::Verify2::WorkflowTest < Vonage::Test
   def test_shovel_method
     flow = workflow
     channel1 = flow.sms(to: e164_compliant_number)
-    channel2 = flow.whatsapp(to: e164_compliant_number)
+    channel2 = flow.whatsapp(to: e164_compliant_number, from: e164_compliant_number)
     flow << channel1
     flow << channel2
 
@@ -51,7 +51,7 @@ class Vonage::Verify2::WorkflowTest < Vonage::Test
   def test_hashified_list_method
     flow = workflow
     flow << flow.sms(to: e164_compliant_number)
-    flow << flow.whatsapp(to: e164_compliant_number)
+    flow << flow.whatsapp(to: e164_compliant_number, from: e164_compliant_number)
 
     hashified_list = flow.hashified_list
     assert hashified_list.all?(Hash)

--- a/test/vonage/verify2_test.rb
+++ b/test/vonage/verify2_test.rb
@@ -135,6 +135,18 @@ class Vonage::Verify2Test < Vonage::Test
     end
   end
 
+  def test_next_workflow_method
+    stub_request(:post, uri + request_id + '/next-workflow').to_return(response)
+
+    assert_kind_of Vonage::Response, verify2.next_workflow(request_id: request_id)
+  end
+
+  def test_next_workflow_method_without_request_id
+    assert_raises ArgumentError do
+      verify2.next_workflow
+    end
+  end
+
   def test_start_verification_options_method
     assert_instance_of Vonage::Verify2::StartVerificationOptions, verify2.start_verification_options
   end


### PR DESCRIPTION
This PR makes some minor updates to the `Verify2` implementation. Specifically it:

- Makes the  `from` field mandatory for `WhatsApp` workflow objects
- Adds a `next_workflow` method
- Adds/updates unit tests for the above changes