### PR TITLE
Verify v2 Validation Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.25.0
+
+* Validation updates to Verify v2 SMS and WhatsApp channels. [#309](https://github.com/Vonage/vonage-ruby-sdk/pull/309)
+
 # 7.24.0
 
 * Updating Video API functionality with methods for Live Captions, Audio Connector, Experience Composer, and a `publisheronly` cleint token role. [#307](https://github.com/Vonage/vonage-ruby-sdk/pull/307)

--- a/lib/vonage/verify2.rb
+++ b/lib/vonage/verify2.rb
@@ -17,6 +17,7 @@ module Vonage
     #   )
     #
     # @param [required, String] :brand The brand that is sending the verification request
+    #   - Must be between 1 and 16 characters in length
     #
     # @param [required, Array<Hash>] :workflow An array of hashes for channels in the workflow
     #
@@ -32,6 +33,8 @@ module Vonage
     # @see https://developer.vonage.com/en/api/verify.v2#newRequest
     #
     def start_verification(brand:, workflow:, **opts)
+      raise ArgumentError, ':workflow must be a String' unless brand.is_a?(String)
+      raise ArgumentError, "Invalid 'brand' value #{brand}. Length must be between 1 and 16 characters." unless brand.length.between?(1, 16)
       raise ArgumentError, ':workflow must be an Array' unless workflow.is_a?(Array)
       raise ArgumentError, ':workflow must not be empty' if workflow.empty?
 

--- a/lib/vonage/verify2.rb
+++ b/lib/vonage/verify2.rb
@@ -33,7 +33,7 @@ module Vonage
     # @see https://developer.vonage.com/en/api/verify.v2#newRequest
     #
     def start_verification(brand:, workflow:, **opts)
-      raise ArgumentError, ':workflow must be a String' unless brand.is_a?(String)
+      raise ArgumentError, ':brand must be a String' unless brand.is_a?(String)
       raise ArgumentError, "Invalid 'brand' value #{brand}. Length must be between 1 and 16 characters." unless brand.length.between?(1, 16)
       raise ArgumentError, ':workflow must be an Array' unless workflow.is_a?(Array)
       raise ArgumentError, ':workflow must not be empty' if workflow.empty?

--- a/lib/vonage/verify2/channels/sms.rb
+++ b/lib/vonage/verify2/channels/sms.rb
@@ -20,6 +20,7 @@ module Vonage
     end
 
     def from=(from)
+      validate_from(from)
       @from = from
     end
 
@@ -49,5 +50,14 @@ module Vonage
     private
 
     attr_writer :channel
+
+    def validate_from(from)
+      if from.match?(/\D/)
+        raise ArgumentError, "Invalid alpha-numeric 'from' value #{from}. Length must be between 3 and 11 characters." unless from.length.between?(3, 11)
+      else
+        raise ArgumentError, "Invalid numeric 'from' value #{from}. Length must be between 11 and 15 characters." unless from.length.between?(11, 15)
+        raise ArgumentError, "Invalid 'from' value #{from}. Expected to be in E.164 format" unless Phonelib.parse(from).valid?
+      end
+    end
   end
 end

--- a/lib/vonage/verify2/channels/whats_app.rb
+++ b/lib/vonage/verify2/channels/whats_app.rb
@@ -19,6 +19,7 @@ module Vonage
     end
 
     def from=(from)
+      raise ArgumentError, "Invalid 'from' value #{from}. Length must be between 11 and 15 characters." unless from.length.between?(11, 15)
       raise ArgumentError, "Invalid 'from' value #{from}. Expected to be in E.164 format" unless Phonelib.parse(from.to_i).valid?
       @from = from
     end

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.24.0'
+  VERSION = '7.25.0'
 end

--- a/test/vonage/test.rb
+++ b/test/vonage/test.rb
@@ -408,7 +408,7 @@ module Vonage
       '447000000000'
     end
 
-    def invalid_number
+    def non_e164_compliant_number
       'abcdefg'
     end
 

--- a/test/vonage/verify2/channels/silent_auth_test.rb
+++ b/test/vonage/verify2/channels/silent_auth_test.rb
@@ -21,9 +21,9 @@ class Vonage::Verify2::Channels::SilentAuthTest < Vonage::Test
     assert_equal new_number, sa_workflow.instance_variable_get(:@to)
   end
 
-  def test_to_setter_method_with_invalid_number
+  def test_to_setter_method_with_non_e164_compliant_number
     assert_raises ArgumentError do
-      silent_auth_channel.to = invalid_number
+      silent_auth_channel.to = non_e164_compliant_number
     end
   end
 

--- a/test/vonage/verify2/channels/sms_test.rb
+++ b/test/vonage/verify2/channels/sms_test.rb
@@ -29,9 +29,9 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     assert_equal new_number, channel.instance_variable_get(:@to)
   end
 
-  def test_to_setter_method_with_invalid_number
+  def test_to_setter_method_with_non_e164_compliant_number
     assert_raises ArgumentError do
-      sms_channel.to = invalid_number
+      sms_channel.to = non_e164_compliant_number
     end
   end
 
@@ -39,12 +39,44 @@ class Vonage::Verify2::Channels::SMSTest < Vonage::Test
     assert_nil sms_channel.from
   end
 
-  def test_from_setter_method
+  def test_from_setter_method_with_valid_numeric
     channel = sms_channel
     new_number = '447000000002'
     channel.from = new_number
 
     assert_equal new_number, channel.instance_variable_get(:@from)
+  end
+
+  def test_from_setter_method_with_valid_alphanumeric
+    channel = sms_channel
+    new_number = 'abc123'
+    channel.from = new_number
+
+    assert_equal new_number, channel.instance_variable_get(:@from)
+  end
+
+  def test_from_setter_method_with_numeric_too_short
+    assert_raises ArgumentError do
+      sms_channel.from = '4470000002'
+    end
+  end
+
+  def test_from_setter_method_with_numeric_too_long
+    assert_raises ArgumentError do
+      sms_channel.from = '4470000000000002'
+    end
+  end
+
+  def test_from_setter_method_with_alphanumeric_too_short
+    assert_raises ArgumentError do
+      sms_channel.from = 'ab'
+    end
+  end
+
+  def test_from_setter_method_with_alphanumeric_too_long
+    assert_raises ArgumentError do
+      sms_channel.from = 'abcdefghijkl'
+    end
   end
 
   def test_entity_id_getter_method

--- a/test/vonage/verify2/channels/voice_test.rb
+++ b/test/vonage/verify2/channels/voice_test.rb
@@ -25,9 +25,9 @@ class Vonage::Verify2::Channels::VoiceTest < Vonage::Test
     assert_equal new_number, channel.instance_variable_get(:@to)
   end
 
-  def test_to_setter_method_with_invalid_number
+  def test_to_setter_method_with_non_e164_compliant_number
     assert_raises ArgumentError do
-      voice_channel.to = invalid_number
+      voice_channel.to = non_e164_compliant_number
     end
   end
 

--- a/test/vonage/verify2/channels/whats_app_interactive_test.rb
+++ b/test/vonage/verify2/channels/whats_app_interactive_test.rb
@@ -25,9 +25,9 @@ class Vonage::Verify2::Channels::WhatsAppInteractiveTest < Vonage::Test
     assert_equal new_number, channel.instance_variable_get(:@to)
   end
 
-  def test_to_setter_method_with_invalid_number
+  def test_to_setter_method_with_non_e164_compliant_number
     assert_raises ArgumentError do
-      whatsapp_interactive_channel.to = invalid_number
+      whatsapp_interactive_channel.to = non_e164_compliant_number
     end
   end
 

--- a/test/vonage/verify2/channels/whats_app_test.rb
+++ b/test/vonage/verify2/channels/whats_app_test.rb
@@ -29,9 +29,9 @@ class Vonage::Verify2::Channels::WhatsAppTest < Vonage::Test
     assert_equal new_number, channel.instance_variable_get(:@to)
   end
 
-  def test_to_setter_method_with_invalid_number
+  def test_to_setter_method_with_non_e164_compliant_number
     assert_raises ArgumentError do
-      whatsapp_channel.to = invalid_number
+      whatsapp_channel.to = non_e164_compliant_number
     end
   end
 
@@ -47,9 +47,21 @@ class Vonage::Verify2::Channels::WhatsAppTest < Vonage::Test
     assert_equal new_number, channel.instance_variable_get(:@from)
   end
 
-  def test_from_setter_method_with_invalid_number
+  def test_from_setter_method_with_non_e164_compliant_number
     assert_raises ArgumentError do
-      whatsapp_channel.from = invalid_number
+      whatsapp_channel.from = non_e164_compliant_number
+    end
+  end
+
+  def test_from_setter_method_with_number_too_short
+    assert_raises ArgumentError do
+      whatsapp_channel.from = '4470000002'
+    end
+  end
+
+  def test_from_setter_method_with_number_too_long
+    assert_raises ArgumentError do
+      whatsapp_channel.from = '4470000000000002'
     end
   end
 

--- a/test/vonage/verify2_test.rb
+++ b/test/vonage/verify2_test.rb
@@ -77,6 +77,22 @@ class Vonage::Verify2Test < Vonage::Test
     end
   end
 
+  def test_start_verification_method_wit_brand_too_short
+    workflow = [{channel: 'sms', to: to_number}]
+
+    assert_raises ArgumentError do
+      verify2.start_verification(brand: '', workflow: workflow)
+    end
+  end
+
+  def test_start_verification_method_wit_brand_too_long
+    workflow = [{channel: 'sms', to: to_number}]
+
+    assert_raises ArgumentError do
+      verify2.start_verification(brand: 'abcdefghijklmnopq', workflow: workflow)
+    end
+  end
+
   def test_start_verification_method_without_workflow
     assert_raises ArgumentError do
       verify2.start_verification(brand: brand)

--- a/test/vonage/verify2_test.rb
+++ b/test/vonage/verify2_test.rb
@@ -77,7 +77,15 @@ class Vonage::Verify2Test < Vonage::Test
     end
   end
 
-  def test_start_verification_method_wit_brand_too_short
+  def test_start_verification_method_with_invalid_brand_type
+    workflow = [{channel: 'sms', to: to_number}]
+
+    assert_raises ArgumentError do
+      verify2.start_verification(brand: 123, workflow: workflow)
+    end
+  end
+
+  def test_start_verification_method_with_brand_too_short
     workflow = [{channel: 'sms', to: to_number}]
 
     assert_raises ArgumentError do
@@ -85,7 +93,7 @@ class Vonage::Verify2Test < Vonage::Test
     end
   end
 
-  def test_start_verification_method_wit_brand_too_long
+  def test_start_verification_method_with_brand_too_long
     workflow = [{channel: 'sms', to: to_number}]
 
     assert_raises ArgumentError do


### PR DESCRIPTION
This PR adds some validtion checks to the Verify v2 implementation. Specifically it:

- Adds a check to the `SMS` class `from` setter to ensure that:
  - Numeric values are between 11 and 15 characters in length
  - Alphanumeric values are between 3 and 11 characters in length
- Adds a check to the `WhatsApp` class `from` setter to ensure that values are between 11 and 15 characters in length
- Adds a check in the `Verify2#start_verification` method to ensure that the `brand` argument is between 1 and 16 characters in length