### PR TITLE
DEVX-8561/DEVX-8603: Verify API and Voice API updates

### DIFF
--- a/lib/vonage/verify2/start_verification_options.rb
+++ b/lib/vonage/verify2/start_verification_options.rb
@@ -5,7 +5,7 @@ module Vonage
   class Verify2::StartVerificationOptions
     VALID_OPTS = [:locale, :channel_timeout, :client_ref, :code_length, :code, :fraud_check].freeze
 
-    MIN_CHANNEL_TIMEOUT, MAX_CHANNEL_TIMEOUT = [60, 900]
+    MIN_CHANNEL_TIMEOUT, MAX_CHANNEL_TIMEOUT = [15, 900]
 
     MIN_CODE_LENGTH, MAX_CODE_LENGTH = [4, 10]
 
@@ -22,6 +22,7 @@ module Vonage
     end
 
     def channel_timeout=(channel_timeout)
+      raise ArgumentError, "Invalid 'channel_timeout' #{channel_timeout}. Must be an integer" unless channel_timeout.is_a?(Integer)
       unless channel_timeout.between?(MIN_CHANNEL_TIMEOUT, MAX_CHANNEL_TIMEOUT)
         raise ArgumentError, "Invalid 'channel_timeout' #{channel_timeout}. Must be between #{MIN_CHANNEL_TIMEOUT} and #{MAX_CHANNEL_TIMEOUT} (inclusive)"
       end

--- a/lib/vonage/voice.rb
+++ b/lib/vonage/voice.rb
@@ -18,6 +18,8 @@ module Vonage
     #
     # @option params [required, Array<Hash>] :to
     #   Connect to a Phone (PSTN) number, SIP Endpoint, Websocket, or VBC extension.
+    #   The `to` Hash can contain a number of different properties depending on the `type`.
+    #   See the API reference for specific details.
     #
     # @option params [Hash] :from
     #   Connect to a Phone (PSTN) number. Should not be set if **:random_from_number** is **true**

--- a/lib/vonage/voice/actions/connect.rb
+++ b/lib/vonage/voice/actions/connect.rb
@@ -209,6 +209,7 @@ module Vonage
       }
 
       hash.merge!(headers: endpoint_attrs[:headers]) if endpoint_attrs[:headers]
+      hash.merge!(standardHeaders: endpoint_attrs[:standardHeaders]) if endpoint_attrs[:standardHeaders]
 
       hash
     end

--- a/test/vonage/verify2/start_verification_options_test.rb
+++ b/test/vonage/verify2/start_verification_options_test.rb
@@ -27,10 +27,38 @@ class Vonage::Verify2::StartVerificationOptionsTest < Vonage::Test
     assert_equal 90, opts.instance_variable_get(:@channel_timeout)
   end
 
+  def test_channel_timeout_setter_method_at_min_value
+    opts = options
+    opts.channel_timeout = 15
+
+    assert_equal 15, opts.instance_variable_get(:@channel_timeout)
+  end
+
+  def test_channel_timeout_setter_method_at_max_value
+    opts = options
+    opts.channel_timeout = 900
+
+    assert_equal 900, opts.instance_variable_get(:@channel_timeout)
+  end
+
+  def test_channel_timeout_setter_method_below_min_value
+    opts = options
+    assert_raises ArgumentError do
+      opts.channel_timeout = 14
+    end
+  end
+
+  def test_channel_timeout_setter_method_above_max_value
+    opts = options
+    assert_raises ArgumentError do
+      opts.channel_timeout = 901
+    end
+  end
+
   def test_channel_timeout_setter_method_with_invalid_arg
     opts = options
     assert_raises ArgumentError do
-      opts.channel_timeout = 0
+      opts.channel_timeout = '90'
     end
   end
 

--- a/test/vonage/voice/ncco_test.rb
+++ b/test/vonage/voice/ncco_test.rb
@@ -17,6 +17,43 @@ class Vonage::Voice::NccoTest < Vonage::Test
     assert_equal action, [{:action=>"connect", :endpoint=>[{:type=>"phone", :number=>"12129999999"}], :from=>'12129992222'}]
   end
 
+  def test_ncco_connect_action_sip_endpoint_with_standard_headers
+    action = ncco.connect(
+      endpoint: {
+        type: 'sip',
+        uri: 'sip:rebekka@sip.mcrussell.com',
+        headers: {
+          location: 'New York',
+          occupation: 'developer'
+        },
+        standardHeaders: {
+          'User-to-User' => '56a390f3d2b7310023a2;encoding=hex;purpose=foo;content=bar'
+        }
+      }
+    )
+
+    action_literal = [
+      {
+        :action=>"connect",
+        :endpoint=>[
+          {
+            :type=>"sip",
+            :uri=>"sip:rebekka@sip.mcrussell.com",
+            :headers=>{
+              location: 'New York',
+              occupation: 'developer'
+            },
+            :standardHeaders => {
+              'User-to-User' => '56a390f3d2b7310023a2;encoding=hex;purpose=foo;content=bar'
+            }
+          }
+        ]
+      }
+    ]
+
+    assert_equal action_literal, action
+  end
+
   def test_ncco_with_invalid_action
     exception = assert_raises { ncco.gotowarp }
     

--- a/test/vonage/voice_test.rb
+++ b/test/vonage/voice_test.rb
@@ -26,6 +26,30 @@ class Vonage::VoiceTest < Vonage::Test
     assert_kind_of Vonage::Response, calls.create(params)
   end
 
+  def test_create_method_with_connect_to_sip_standard_headers
+    params = {
+      to: [
+        {
+          type: 'sip',
+          uri: 'sip:rebekka@sip.example.com',
+          headers: {
+            location: 'New York',
+            occupation: 'developer'
+          },
+          standard_headers: {
+            'User-to-User' => '56a390f3d2b7310023a2;encoding=hex;purpose=foo;content=bar'
+          }
+        }
+      ],
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+
+    stub_request(:post, calls_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, calls.create(params)
+  end
+
   def test_create_method_raises_error_if_from_set_and_random_from_number_true
     params = {
       to: [{type: 'phone', number: '14843331234'}],


### PR DESCRIPTION
This PR makes changes to the implementation for Verify2 and Voice. Specificaly it:

## Verify

- Updates the `Verify2::StartVerificationOptions` class to amend the `MIN_CHANNEL_TIMEOUT` value to `15`
- Updates existing tests and adds new tests to better cover the change in value

## Voice

- Updates the code comments for the `to` parameter of the `Voice#create` method
- Updates the `sip_endpoint` method in the `Voice::Actions::Connect` class to merge in `standardHeaders` if it exists
- Adds unit tests for the `Voice#create` method with SIP `standard_header` and NCCO `connect` action with SIP `standardHeaders`