### PR TITLE
DEVX-9024: Fixing bug with HTTP Options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.27.1
+
+* Fixes a bug with setting options on the HTTP client. [#319](https://github.com/Vonage/vonage-ruby-sdk/pull/319)
+
 # 7.27.0
 
 * Updates Messages API implementation to add RCS channel as well as a new `PATCH` endpoint for RCS message revocation and WhatsApp Mark as Read features. [#316](https://github.com/Vonage/vonage-ruby-sdk/pull/316)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ need a Vonage account. Sign up [for free at vonage.com][signup].
     * [Logging](#logging)
     * [Exceptions](#exceptions)
     * [Overriding the default hosts](#overriding-the-default-hosts)
+    * [HTTP Client Configuration](#http-client-configuration)
     * [JWT authentication](#jwt-authentication)
     * [Webhook signatures](#webhook-signatures)
     * [Pagination](#pagination)
@@ -178,6 +179,33 @@ client = Vonage::Client.new(
 ```
 
 By default the hosts are set to `api.nexmo.com` and `rest.nexmo.com`, respectively.
+
+### HTTP Client Configuration
+
+It is possible to set configuration options on the HTTP client. This can be don in a couple of ways.
+
+1. Using an `:http` key during `Vonage::Client` instantiation, for example:
+    ```ruby
+    client = Vonage::Client.new(
+      api_key: 'YOUR-API-KEY',
+      api_secret: 'YOUR-API-SECRET',
+      http: {
+        max_retries: 1
+      }
+    )
+    ```
+
+2. By using the `http=` setter on the `Vonage::Config` object, for example:
+    ```ruby
+    client = Vonage::Client.new(
+      api_key: 'YOUR-API-KEY',
+      api_secret: 'YOUR-API-SECRET'
+    )
+
+    client.config.http = { max_retries: 1 }
+    ```
+
+The Vonage Ruby SDK uses the [`Net::HTTP::Persistent` library](https://github.com/drbrain/net-http-persistent) as an HTTP client. For available configuration options see [the documentation for that library](https://www.rubydoc.info/gems/net-http-persistent/3.0.0/Net/HTTP/Persistent).
 
 ### Webhook signatures
 

--- a/lib/vonage/http.rb
+++ b/lib/vonage/http.rb
@@ -1,6 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
-require 'net/http'
+require 'net/http/persistent'
 
 module Vonage
   module HTTP
@@ -21,7 +21,7 @@ module Vonage
         end
       end
 
-      sig { params(http: Net::HTTP).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(http: Net::HTTP::Persistent).returns(T::Hash[Symbol, T.untyped]) }
       def set(http)
         @hash.each do |name, value|
           http.public_send(defined_options.fetch(name), value)
@@ -34,7 +34,7 @@ module Vonage
       def defined_options
         @defined_options = T.let(@defined_options, T.nilable(T::Hash[Symbol, T.untyped]))
 
-        @defined_options ||= Net::HTTP.instance_methods.grep(/\w=\z/).each_with_object({}) do |name, hash|
+        @defined_options ||= Net::HTTP::Persistent.instance_methods.grep(/\w=\z/).each_with_object({}) do |name, hash|
           hash[name.to_s.chomp('=').to_sym] = name
         end
       end

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.27.0'
+  VERSION = '7.27.1'
 end

--- a/test/vonage/http_options_test.rb
+++ b/test/vonage/http_options_test.rb
@@ -8,8 +8,12 @@ class Vonage::HTTPOptionsTest < Minitest::Test
     5
   end
 
-  def proxy_address
-    'localhost'
+  def proxy_host
+    'example.com'
+  end
+
+  def proxy_port
+    4567
   end
 
   def ca_file
@@ -23,13 +27,16 @@ class Vonage::HTTPOptionsTest < Minitest::Test
   end
 
   def test_set_method
-    http = Net::HTTP.new('example.com', Net::HTTP.https_default_port, p_addr = nil)
+    http = Net::HTTP::Persistent.new
 
-    options = Options.new(read_timeout: read_timeout, proxy_address: proxy_address, ca_file: ca_file)
+    proxy = URI::HTTP.build(host: proxy_host, port: proxy_port)
+
+    options = Options.new(read_timeout: read_timeout, proxy: proxy, ca_file: ca_file)
     options.set(http)
 
     assert_equal read_timeout, http.read_timeout
-    assert_equal proxy_address, http.proxy_address
+    assert_equal proxy_host, http.proxy_uri.hostname
+    assert_equal proxy_port, http.proxy_uri.port
     assert_equal ca_file, http.ca_file
   end
 end


### PR DESCRIPTION
This PR fixes a bug with setting options on the HTTP Client. Specifically it:

- Updates the `HTTP::Options` class to work with `Net::HTTP::Persistent` rather than `Net::HTTP`
- Updates the asscoiated tests
- Updates the README to provide an overview of the functionality