### PR TITLE
DEVX-9003: Add max_bitrate to Video::Archives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.29.0
+
+* Adds `max_bitrate` as an option to the `Video::Archives#start` method. [#321](https://github.com/Vonage/vonage-ruby-sdk/pull/321)
+
 # 7.28.0
 
 * Adds templates and template fragments to the Verify v2 implementation. [#318](https://github.com/Vonage/vonage-ruby-sdk/pull/318)

--- a/lib/vonage/keys.rb
+++ b/lib/vonage/keys.rb
@@ -28,8 +28,10 @@ module Vonage
         'remove_stream',
         'screenshare_type',
         'session_id',
+        'output_mode',
         'stream_mode',
         'archive_mode',
+        'multi_archive_tag',
         'language_code',
         'max_duration',
         'partial_captions',
@@ -37,7 +39,8 @@ module Vonage
         'audio_rate',
         'phone_number',
         'hashed_phone_number',
-        'max_age'
+        'max_age',
+        'max_bitrate'
       ]
       hash.transform_keys do |k|
         if exceptions.include?(k.to_s)

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.28.0'
+  VERSION = '7.29.0'
 end

--- a/lib/vonage/video/archives.rb
+++ b/lib/vonage/video/archives.rb
@@ -45,19 +45,21 @@ module Vonage
     #
     # @param [required, String] :session_id
     #
-    # @param [optional, String] :hasAudio
+    # @param [optional, String] :has_audio
     #
-    # @param [optional, String] :hasVideo
+    # @param [optional, String] :has_video
     #
     # @param [optional, String] :name
     #
-    # @param [optional, String] :outputMode
+    # @param [optional, String] :output_mode
     #
     # @param [optional, String] :resolution
     #
-    # @param [optional, String] :streamMode
+    # @param [optional, String] :stream_mode
     #
-    # @param [optional, String] :multiArchiveTag
+    # @param [optional, String] :multi_archive_tag
+    #
+    # @param [optional, String] :max_bitrate
     #
     # @param [optional, Hash] :layout
     #

--- a/test/vonage/video/archives_test.rb
+++ b/test/vonage/video/archives_test.rb
@@ -43,7 +43,8 @@ class Vonage::Video::ArchivesTest < Vonage::Test
     request_params = {
       sessionId: video_session_id,
       resolution: '640x480',
-      streamMode: 'auto'
+      streamMode: 'auto',
+      maxBitrate: 200000
     }
 
     stub_request(:post, uri).with(body: request_params).to_return(response)
@@ -51,7 +52,8 @@ class Vonage::Video::ArchivesTest < Vonage::Test
     assert_kind_of Vonage::Response, archives.start(
       session_id: video_session_id,
       resolution: '640x480',
-      stream_mode: 'auto'
+      stream_mode: 'auto',
+      max_bitrate: 200000
     )
   end
 


### PR DESCRIPTION
This PR updates the functionality for the `Video::Archives#start` method to add `max_bitrate` as an option and updates the corresponding unit test.