### PR TITLE
feat: add failover to messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.30.0
+
+* Implements the Failover feature in Messages API. [#327](https://github.com/Vonage/vonage-ruby-sdk/pull/327)
+
 # 7.29.1
 
 * Fixes a bug with the Viber Service Messages API channel. [#323](https://github.com/Vonage/vonage-ruby-sdk/pull/323)

--- a/lib/vonage/messaging.rb
+++ b/lib/vonage/messaging.rb
@@ -27,8 +27,17 @@ module Vonage
     #
     # @see https://developer.vonage.com/api/messages#SendMessage
     #
-    def send(to:, from:, channel:, message_type:, **message)
-      request('/v1/messages', params: {to: to, from: from, channel: channel, message_type: message_type, **message}, type: Post)
+    def send(to:, from:, channel:, message_type:, failover: nil, **message)
+      params = { to: to, from: from, channel: channel, message_type: message_type }.merge(message)
+
+      if failover
+        raise ArgumentError.new("`failover` must be an array") unless failover.is_a?(Array)
+        raise ArgumentError.new("`failover` must not be empty") if failover.empty?
+        raise ArgumentError.new("`failover` must contain only Hashes") unless failover.all?(Hash)
+        params[:failover] = failover
+      end
+
+      request('/v1/messages', params: params, type: Post)
     end
 
     # Update a Message Object.

--- a/lib/vonage/messaging.rb
+++ b/lib/vonage/messaging.rb
@@ -27,8 +27,8 @@ module Vonage
     #
     # @see https://developer.vonage.com/api/messages#SendMessage
     #
-    def send(to:, from:, **message)
-      request('/v1/messages', params: {to: to, from: from, **message}, type: Post)
+    def send(to:, from:, channel:, message_type:, **message)
+      request('/v1/messages', params: {to: to, from: from, channel: channel, message_type: message_type, **message}, type: Post)
     end
 
     # Update a Message Object.

--- a/lib/vonage/messaging/channels/messenger.rb
+++ b/lib/vonage/messaging/channels/messenger.rb
@@ -7,6 +7,8 @@ module Vonage
     attr_reader :data
 
     def initialize(attributes = {})
+      @to = attributes.fetch(:to, nil)
+      @from = attributes.fetch(:from, nil)
       @type = attributes.fetch(:type, nil)
       @message = attributes.fetch(:message, nil)
       @opts = attributes.fetch(:opts, {})

--- a/lib/vonage/messaging/channels/mms.rb
+++ b/lib/vonage/messaging/channels/mms.rb
@@ -7,6 +7,8 @@ module Vonage
     attr_reader :data
 
     def initialize(attributes = {})
+      @to = attributes.fetch(:to, nil)
+      @from = attributes.fetch(:from, nil)
       @type = attributes.fetch(:type, nil)
       @message = attributes.fetch(:message, nil)
       @opts = attributes.fetch(:opts, {})

--- a/lib/vonage/messaging/channels/rcs.rb
+++ b/lib/vonage/messaging/channels/rcs.rb
@@ -7,6 +7,8 @@ module Vonage
     attr_reader :data
 
     def initialize(attributes = {})
+      @to = attributes.fetch(:to, nil)
+      @from = attributes.fetch(:from, nil)
       @type = attributes.fetch(:type, nil)
       @message = attributes.fetch(:message, nil)
       @opts = attributes.fetch(:opts, {})

--- a/lib/vonage/messaging/channels/sms.rb
+++ b/lib/vonage/messaging/channels/sms.rb
@@ -5,6 +5,8 @@ module Vonage
     attr_reader :data
 
     def initialize(attributes = {})
+      @to = attributes.fetch(:to, nil)
+      @from = attributes.fetch(:from, nil)
       @type = attributes.fetch(:type, 'text')
       @message = attributes.fetch(:message, nil)
       @opts = attributes.fetch(:opts, {})

--- a/lib/vonage/messaging/channels/viber.rb
+++ b/lib/vonage/messaging/channels/viber.rb
@@ -7,6 +7,8 @@ module Vonage
     attr_reader :data
 
     def initialize(attributes = {})
+      @to = attributes.fetch(:to, nil)
+      @from = attributes.fetch(:from, nil)
       @type = attributes.fetch(:type, nil)
       @message = attributes.fetch(:message, nil)
       @opts = attributes.fetch(:opts, {})

--- a/lib/vonage/messaging/channels/whats_app.rb
+++ b/lib/vonage/messaging/channels/whats_app.rb
@@ -7,6 +7,8 @@ module Vonage
     attr_reader :data
 
     def initialize(attributes = {})
+      @to = attributes.fetch(:to, nil)
+      @from = attributes.fetch(:from, nil)
       @type = attributes.fetch(:type, nil)
       @message = attributes.fetch(:message, nil)
       @opts = attributes.fetch(:opts, {})

--- a/lib/vonage/messaging/message.rb
+++ b/lib/vonage/messaging/message.rb
@@ -25,7 +25,7 @@ module Vonage
 
     private
 
-    attr_accessor :type, :message, :opts
+    attr_accessor :to, :from, :type, :message, :opts
     attr_writer :data
 
     def after_initialize!
@@ -35,6 +35,8 @@ module Vonage
     end
 
     def build
+      data[:to] = to if to
+      data[:from] = from if from
       data[:message_type] = type
       data[type.to_sym] = message
       data.merge!(opts)

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.29.1'
+  VERSION = '7.30.0'
 end

--- a/test/vonage/messaging/channels/messenger_test.rb
+++ b/test/vonage/messaging/channels/messenger_test.rb
@@ -89,4 +89,31 @@ class Vonage::Messaging::Channels::MessengerTest < Vonage::Test
     assert_equal 'response', messenger.data[:messenger][:category]
     assert_equal 'CONFIRMED_EVENT_UPDATE', messenger.data[:messenger][:tag]
   end
+
+  def test_with_to_specified
+    to_number = '447900000000'
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!', to: to_number)
+
+    assert_equal to_number, messenger.data[:to]
+    assert_includes messenger.data, :to
+  end
+
+  def test_with_from_specified
+    from_number = '447900000001'
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!', from: from_number)
+
+    assert_equal from_number, messenger.data[:from]
+    assert_includes messenger.data, :from
+  end
+
+  def test_with_to_and_from_specified
+    to_number = '447900000000'
+    from_number = '447900000001'
+    messenger = Vonage::Messaging::Channels::Messenger.new(type: 'text', message: 'Hello world!', to: to_number, from: from_number)
+
+    assert_equal to_number, messenger.data[:to]
+    assert_equal from_number, messenger.data[:from]
+    assert_includes messenger.data, :to
+    assert_includes messenger.data, :from
+  end
 end

--- a/test/vonage/messaging/channels/mms_test.rb
+++ b/test/vonage/messaging/channels/mms_test.rb
@@ -77,6 +77,33 @@ class Vonage::Messaging::Channels::MMSTest < Vonage::Test
     assert_match ":url is required in :message", exception.message
   end
 
+  def test_with_to_specified
+    to_number = '447900000000'
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' }, to: to_number)
+
+    assert_equal to_number, mms.data[:to]
+    assert_includes mms.data, :to
+  end
+
+  def test_with_from_specified
+    from_number = '447900000001'
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' }, from: from_number)
+
+    assert_equal from_number, mms.data[:from]
+    assert_includes mms.data, :from
+  end
+
+  def test_with_to_and_from_specified
+    to_number = '447900000000'
+    from_number = '447900000001'
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' }, to: to_number, from: from_number)
+
+    assert_equal to_number, mms.data[:to]
+    assert_equal from_number, mms.data[:from]
+    assert_includes mms.data, :to
+    assert_includes mms.data, :from
+  end
+
   def test_with_opts
     mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' }, opts: { client_ref: 'abc123' })
 

--- a/test/vonage/messaging/channels/rcs_test.rb
+++ b/test/vonage/messaging/channels/rcs_test.rb
@@ -223,4 +223,31 @@ class Vonage::Messaging::Channels::RCSTest < Vonage::Test
     assert_instance_of Vonage::ClientError, exception
     assert_match "Invalid parameter content. `:message` must not be empty", exception.message
   end
+
+  def test_with_to_specified
+    to_number = '447900000000'
+    rcs = Vonage::Messaging::Channels::RCS.new(type: 'text', message: 'Hello world!', to: to_number)
+
+    assert_equal to_number, rcs.data[:to]
+    assert_includes rcs.data, :to
+  end
+
+  def test_with_from_specified
+    from_number = '447900000001'
+    rcs = Vonage::Messaging::Channels::RCS.new(type: 'text', message: 'Hello world!', from: from_number)
+
+    assert_equal from_number, rcs.data[:from]
+    assert_includes rcs.data, :from
+  end
+
+  def test_with_to_and_from_specified
+    to_number = '447900000000'
+    from_number = '447900000001'
+    rcs = Vonage::Messaging::Channels::RCS.new(type: 'text', message: 'Hello world!', to: to_number, from: from_number)
+
+    assert_equal to_number, rcs.data[:to]
+    assert_equal from_number, rcs.data[:from]
+    assert_includes rcs.data, :to
+    assert_includes rcs.data, :from
+  end
 end

--- a/test/vonage/messaging/channels/sms_test.rb
+++ b/test/vonage/messaging/channels/sms_test.rb
@@ -40,6 +40,33 @@ class Vonage::Messaging::Channels::SMSTest < Vonage::Test
     assert_match ":message must be a String", exception.message
   end
 
+  def test_with_to_specified
+    to_number = '447900000000'
+    sms = Vonage::Messaging::Channels::SMS.new(message: 'Hello world!', to: to_number)
+
+    assert_equal to_number, sms.data[:to]
+    assert_includes sms.data, :to
+  end
+
+  def test_with_from_specified
+    from_number = '447900000001'
+    sms = Vonage::Messaging::Channels::SMS.new(message: 'Hello world!', from: from_number)
+
+    assert_equal from_number, sms.data[:from]
+    assert_includes sms.data, :from
+  end
+
+  def test_with_to_and_from_specified
+    to_number = '447900000000'
+    from_number = '447900000001'
+    sms = Vonage::Messaging::Channels::SMS.new(message: 'Hello world!', to: to_number, from: from_number)
+
+    assert_equal to_number, sms.data[:to]
+    assert_equal from_number, sms.data[:from]
+    assert_includes sms.data, :to
+    assert_includes sms.data, :from
+  end
+
   def test_with_opts
     sms = Vonage::Messaging::Channels::SMS.new(type: 'text', message: 'Hello world!', opts: { client_ref: 'abc123' })
 

--- a/test/vonage/messaging/channels/viber_test.rb
+++ b/test/vonage/messaging/channels/viber_test.rb
@@ -109,4 +109,31 @@ class Vonage::Messaging::Channels::ViberTest < Vonage::Test
     assert_equal 'transaction', viber.data[:viber_service][:category]
     assert_equal 600, viber.data[:viber_service][:ttl]
   end
+
+  def test_with_to_specified
+    to_number = '447900000000'
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!', to: to_number)
+
+    assert_equal to_number, viber.data[:to]
+    assert_includes viber.data, :to
+  end
+
+  def test_with_from_specified
+    from_number = '447900000001'
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!', from: from_number)
+
+    assert_equal from_number, viber.data[:from]
+    assert_includes viber.data, :from
+  end
+
+  def test_with_to_and_from_specified
+    to_number = '447900000000'
+    from_number = '447900000001'
+    viber = Vonage::Messaging::Channels::Viber.new(type: 'text', message: 'Hello world!', to: to_number, from: from_number)
+
+    assert_equal to_number, viber.data[:to]
+    assert_equal from_number, viber.data[:from]
+    assert_includes viber.data, :to
+    assert_includes viber.data, :from
+  end
 end

--- a/test/vonage/messaging/channels/whats_app_test.rb
+++ b/test/vonage/messaging/channels/whats_app_test.rb
@@ -152,4 +152,31 @@ class Vonage::Messaging::Channels::WhatsAppTest < Vonage::Test
 
     assert_equal 'abc123', whatsapp.data[:client_ref]
   end
+
+  def test_with_to_specified
+    to_number = '447900000000'
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'text', message: 'Hello world!', to: to_number)
+
+    assert_equal to_number, whatsapp.data[:to]
+    assert_includes whatsapp.data, :to
+  end
+
+  def test_with_from_specified
+    from_number = '447900000001'
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'text', message: 'Hello world!', from: from_number)
+
+    assert_equal from_number, whatsapp.data[:from]
+    assert_includes whatsapp.data, :from
+  end
+
+  def test_with_to_and_from_specified
+    to_number = '447900000000'
+    from_number = '447900000001'
+    whatsapp = Vonage::Messaging::Channels::WhatsApp.new(type: 'text', message: 'Hello world!', to: to_number, from: from_number)
+
+    assert_equal to_number, whatsapp.data[:to]
+    assert_equal from_number, whatsapp.data[:from]
+    assert_includes whatsapp.data, :to
+    assert_includes whatsapp.data, :from
+  end
 end

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -38,7 +38,7 @@ class Vonage::MessagingTest < Vonage::Test
 
     stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
 
-    message = Vonage::Messaging::Message.sms(message: "Hello world!")
+    message = messaging.sms(message: "Hello world!")
 
     assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
   end

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -166,4 +166,132 @@ class Vonage::MessagingTest < Vonage::Test
 
     assert_kind_of Vonage::Response, geo_specific_messaging.update(message_uuid: message_uuid, status: 'read')
   end
+
+  # The below tests are to ensure backwards compatibility with the previous send method implementation
+
+  def test_send_method_with_builder_setting_to_and_from
+    params = {
+      to: "447700900000",
+      from: "447700900001",
+      channel: "sms",
+      message_type: "text",
+      text: "Hello world!"
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = messaging.sms(to: "447700900000", from: "447700900001", message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging.send(**message)
+  end
+
+  def test_send_method_with_method_setting_to_and_from_with_failover
+    params = {
+      to: "447700900000",
+      from: "Vonage",
+      channel: "rcs",
+      message_type: "text",
+      text: "Hello world!",
+      failover: [
+        {
+          to: "447700900000",
+          from: "447700900001",
+          channel: "sms",
+          message_type: "text",
+          text: "Hello world!"
+        }
+      ]
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = messaging.rcs(type: 'text', message: "Hello world!")
+    failover_message = messaging.sms(to: "447700900000", from: "447700900001", message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "Vonage", **message, failover: [failover_message])
+  end
+
+  def test_send_method_with_builder_setting_to_and_method_setting_from
+    params = {
+      to: "447700900000",
+      from: "447700900001",
+      channel: "sms",
+      message_type: "text",
+      text: "Hello world!"
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = messaging.sms(to: "447700900000", message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging.send(from: "447700900001", **message)
+  end
+
+  def test_send_method_with_method_setting_to_and_builder_setting_from
+    params = {
+      to: "447700900000",
+      from: "447700900001",
+      channel: "sms",
+      message_type: "text",
+      text: "Hello world!"
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = messaging.sms(from: "447700900001", message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging.send(to: "447700900000", **message)
+  end
+
+  def test_send_method_with_builder_setting_to_and_method_setting_from_with_failover
+    params = {
+      to: "447700900000",
+      from: "Vonage",
+      channel: "rcs",
+      message_type: "text",
+      text: "Hello world!",
+      failover: [
+        {
+          to: "447700900000",
+          from: "447700900001",
+          channel: "sms",
+          message_type: "text",
+          text: "Hello world!"
+        }
+      ]
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = messaging.rcs(to: "447700900000", type: 'text', message: "Hello world!")
+    failover_message = messaging.sms(to: "447700900000", from: "447700900001", message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging.send(from: "Vonage", **message, failover: [failover_message])
+  end
+
+  def test_send_method_with_method_setting_to_and_builder_setting_from_with_failover
+    params = {
+      to: "447700900000",
+      from: "Vonage",
+      channel: "rcs",
+      message_type: "text",
+      text: "Hello world!",
+      failover: [
+        {
+          to: "447700900000",
+          from: "447700900001",
+          channel: "sms",
+          message_type: "text",
+          text: "Hello world!"
+        }
+      ]
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
+
+    message = messaging.rcs(from: "Vonage", type: 'text', message: "Hello world!")
+    failover_message = messaging.sms(to: "447700900000", from: "447700900001", message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging.send(to: "447700900000", **message, failover: [failover_message])
+  end
 end

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -113,7 +113,7 @@ class Vonage::MessagingTest < Vonage::Test
     stub_request(:post, messaging_uri).with(request(body: params)).to_return(response)
 
     message = messaging.rcs(to: "447700900000", from: "Vonage", type: 'text', message: "Hello world!")
-    failover_message_1 = messaging.whatsapp(to: "447700900000", from: "447700900001", message: "Hello world!")
+    failover_message_1 = messaging.whatsapp(to: "447700900000", from: "447700900001", type: 'text', message: "Hello world!")
     failover_message_2 = messaging.sms(to: "447700900000", from: "447700900001", message: "Hello world!")
 
     assert_kind_of Vonage::Response, messaging.send(**message, failover: [failover_message_1, failover_message_2])

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -44,11 +44,19 @@ class Vonage::MessagingTest < Vonage::Test
   end
 
   def test_send_method_without_to
-    assert_raises(ArgumentError) { messaging.send(from: "447700900001", message: "Hello world!") }
+    assert_raises(ArgumentError) { messaging.send(from: "447700900001", channel: 'sms', message_type: 'text', text: "Hello world!") }
   end
 
   def test_send_method_without_from
-    assert_raises(ArgumentError) { messaging.send(to: "447700900000", message: "Hello world!") }
+    assert_raises(ArgumentError) { messaging.send(to: "447700900000", channel: 'sms', message_type: 'text', text: "Hello world!") }
+  end
+
+  def test_send_method_without_channel
+    assert_raises(ArgumentError) { messaging.send(to: "447700900000", from: "447700900001", message_type: 'text', text: "Hello world!") }
+  end
+
+  def test_send_method_without_message_type
+    assert_raises(ArgumentError) { messaging.send(to: "447700900000", from: "447700900001", channel: 'sms', text: "Hello world!") }
   end
 
   def test_verify_webhook_token_method_with_valid_secret_passed_in


### PR DESCRIPTION
This PR adds the failover feature to the Messages API implementation. Specifically it:

- Updates the `Messaging#send` method to take a `failover` parameter
- Updates the per-channel message builder methods to accept `to` and `from` params
- Adds/updates tests for the new and updated functionality