### PR TITLE
chore: Prep release 7.30.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.30.1
+
+* Fixes an incorrect path in the `Verify2#next_workflow` method. See [#329](https://github.com/Vonage/vonage-ruby-sdk/pull/329).
+
 # 7.30.0
 
 * Implements the Failover feature in Messages API. [#327](https://github.com/Vonage/vonage-ruby-sdk/pull/327)

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.30.0'
+  VERSION = '7.30.1'
 end


### PR DESCRIPTION
This PR prepares for release 7.3.1. Specifically it:

- Bumps the patch version in `version.rb`
- Updates the `CHANGES.md` file