### PR TITLE
fix: Removing Sorbet type signatures from Logger methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.30.2
+
+* Removes type signatures for `Logger` setter and initialization methods. See [#333](https://github.com/Vonage/vonage-ruby-sdk/pull/333)
+
 # 7.30.1
 
 * Fixes an incorrect path in the `Verify2#next_workflow` method. See [#329](https://github.com/Vonage/vonage-ruby-sdk/pull/329).

--- a/lib/vonage/config.rb
+++ b/lib/vonage/config.rb
@@ -131,11 +131,6 @@ module Vonage
 
     # @return [Vonage::Logger]
     #
-    sig { params(logger: T.nilable(
-      defined?(ActiveSupport::BroadcastLogger) ?
-        T.any(::Logger, Vonage::Logger, ActiveSupport::BroadcastLogger)
-      : T.any(::Logger, Vonage::Logger)
-    )).returns(T.nilable(Vonage::Logger)) }
     def logger=(logger)
       @logger = T.let(Logger.new(logger), T.nilable(Vonage::Logger))
     end

--- a/lib/vonage/logger.rb
+++ b/lib/vonage/logger.rb
@@ -7,11 +7,6 @@ module Vonage
   class Logger
     extend T::Sig
 
-    sig { params(logger: T.nilable(
-      defined?(ActiveSupport::BroadcastLogger) ?
-        T.any(::Logger, Vonage::Logger, ActiveSupport::BroadcastLogger)
-      : T.any(::Logger, Vonage::Logger)
-    )).void }
     def initialize(logger)
       @logger = logger || ::Logger.new(nil)
     end

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.30.1'
+  VERSION = '7.30.2'
 end


### PR DESCRIPTION
This PR removes the Sorbet type signatures from the `Logger` setter and initialization methods in order to fix a type error encountered when using Semantic Logger with Rails. For a more detailed explanation of this see [this comment](https://github.com/Vonage/vonage-ruby-sdk/pull/332#discussion_r2288800472).

Fixes #320