### PR TITLE
feat: SMS and Messages Updates Q3 2025

### DIFF
--- a/lib/vonage/messaging/channels/mms.rb
+++ b/lib/vonage/messaging/channels/mms.rb
@@ -2,7 +2,7 @@
 
 module Vonage
   class Messaging::Channels::MMS < Messaging::Message
-    MESSAGE_TYPES = ['image', 'vcard', 'audio', 'video']
+    MESSAGE_TYPES = ['text', 'image', 'vcard', 'audio', 'video', 'file', 'content'].freeze
 
     attr_reader :data
 
@@ -29,8 +29,16 @@ module Vonage
     end
 
     def verify_message
-      raise Vonage::ClientError.new(":message must be a Hash") unless message.is_a? Hash
-      raise Vonage::ClientError.new(":url is required in :message") unless message[:url]
+      case type
+      when 'text'
+        raise Vonage::ClientError.new("Invalid parameter type. `:message` must be a String") unless message.is_a? String
+      when 'content'
+        raise Vonage::ClientError.new("Invalid parameter type. `:message` must be an Array") unless message.is_a? Array
+        raise Vonage::ClientError.new("Invalid parameter content. `:message` must not be empty") if message.empty?
+      else
+        raise Vonage::ClientError.new("Invalid parameter type. `:message` must be a Hash") unless message.is_a? Hash
+        raise Vonage::ClientError.new("Missing parameter. `:message` must contain a `:url` key") unless message[:url]
+      end
     end
   end
 end

--- a/lib/vonage/messaging/channels/rcs.rb
+++ b/lib/vonage/messaging/channels/rcs.rb
@@ -2,7 +2,7 @@
 
 module Vonage
   class Messaging::Channels::RCS < Messaging::Message
-    MESSAGE_TYPES = ['text', 'image', 'video', 'file', 'custom']
+    MESSAGE_TYPES = ['text', 'image', 'video', 'file', 'card', 'carousel', 'custom']
 
     attr_reader :data
 
@@ -32,7 +32,7 @@ module Vonage
       case type
       when 'text'
         raise Vonage::ClientError.new("Invalid parameter type. `:message` must be a String") unless message.is_a? String
-      when 'custom'
+      when 'card', 'carousel', 'custom'
         raise Vonage::ClientError.new("Invalid parameter type. `:message` must be a Hash") unless message.is_a? Hash
         raise Vonage::ClientError.new("Invalid parameter content. `:message` must not be empty") if message.empty?
       else

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -66,6 +66,9 @@ module Vonage
     #   An optional string used to identify separate accounts using the SMS endpoint for billing purposes.
     #   To use this feature, please email [support@nexmo.com](mailto:support@nexmo.com).
     #
+    # @option params [String] :trusted_number
+    #   Setting this parameter to true overrides, on a per-message basis, any protections set up via Fraud Defender (Traffic Rules, SMS Burst Protection, AIT Protection).
+    #
     # @param [Hash] params
     #
     # @return [Response]

--- a/test/vonage/messaging/channels/mms_test.rb
+++ b/test/vonage/messaging/channels/mms_test.rb
@@ -9,6 +9,13 @@ class Vonage::Messaging::Channels::MMSTest < Vonage::Test
     assert_equal mms.data, { channel: 'mms', message_type: 'image', image: { url: 'https://example.com/image.jpg' } }
   end
 
+  def test_with_valid_type_text_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'text', message: 'Hello world!')
+
+    assert_equal 'text', mms.data[:message_type]
+    assert_includes mms.data, :text
+  end
+
   def test_with_valid_type_image_specified
     mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' })
 
@@ -37,9 +44,23 @@ class Vonage::Messaging::Channels::MMSTest < Vonage::Test
     assert_includes mms.data, :video
   end
 
+  def test_with_valid_type_file_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'file', message: { url: 'https://example.com/file.pdf' })
+
+    assert_equal 'file', mms.data[:message_type]
+    assert_includes mms.data, :file
+  end
+
+  def test_with_valid_type_content_specified
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'content', message: [{ type: "image", url: 'https://example.com/image.jpg' }])
+
+    assert_equal 'content', mms.data[:message_type]
+    assert_includes mms.data, :content
+  end
+
   def test_with_invalid_type_specified
     exception = assert_raises {
-      Vonage::Messaging::Channels::MMS.new(type: 'text', message: { url: 'https://example.com/video.mp4' })
+      Vonage::Messaging::Channels::MMS.new(type: 'foo', message: { url: 'https://example.com/video.mp4' })
     }
 
     assert_instance_of Vonage::ClientError, exception
@@ -58,7 +79,7 @@ class Vonage::Messaging::Channels::MMSTest < Vonage::Test
     }
 
     assert_instance_of Vonage::ClientError, exception
-    assert_match ":message must be a Hash", exception.message
+    assert_match "Invalid parameter type. `:message` must be a Hash", exception.message
   end
 
   def test_with_caption
@@ -74,7 +95,7 @@ class Vonage::Messaging::Channels::MMSTest < Vonage::Test
     }
 
     assert_instance_of Vonage::ClientError, exception
-    assert_match ":url is required in :message", exception.message
+    assert_match "Missing parameter. `:message` must contain a `:url` key", exception.message
   end
 
   def test_with_to_specified

--- a/test/vonage/messaging/channels/rcs_test.rb
+++ b/test/vonage/messaging/channels/rcs_test.rb
@@ -52,6 +52,37 @@ class Vonage::Messaging::Channels::RCSTest < Vonage::Test
     assert_equal expected, message.data
   end
 
+  def test_rcs_text_message_wth_suggestions
+    expected = {
+      channel: 'rcs',
+      message_type: 'text',
+      text: 'Hello world!',
+      suggestions: [
+        {
+          type: 'reply',
+          text: 'Yes',
+          postback: 'question_1_yes'
+        }
+      ]
+    }
+
+    message = Vonage::Messaging::Channels::RCS.new(
+      type: 'text',
+      message: 'Hello world!',
+      opts: {
+        suggestions: [
+          {
+            type: 'reply',
+            text: 'Yes',
+            postback: 'question_1_yes'
+          }
+        ]
+      }
+    )
+
+    assert_equal expected, message.data
+  end
+
   def test_rcs_image_message
     expected = {
       channel: 'rcs',
@@ -103,6 +134,221 @@ class Vonage::Messaging::Channels::RCSTest < Vonage::Test
       type: 'file',
       message: {
         url: 'https://example.com/file.pdf'
+      }
+    )
+
+    assert_equal expected, message.data
+  end
+
+  def test_rcs_card_message
+    expected = {
+      channel: 'rcs',
+      message_type: 'card',
+      card: {
+        title: 'Card Title',
+        text: 'Card Description',
+        media_url:  'https://example.com/image.jpg',
+        suggestions: [
+          {
+            type: 'reply',
+            text: 'Yes',
+            postback_data: 'question_1_yes'
+          }
+        ]
+      },
+      rcs: {
+        card_orientation: 'VERTICAL',
+        image_alignment: 'LEFT'
+      }
+    }
+
+    message = Vonage::Messaging::Channels::RCS.new(
+      type: 'card',
+      message: {
+        title: 'Card Title',
+        text: 'Card Description',
+        media_url:  'https://example.com/image.jpg',
+        suggestions: [
+          {
+            type: 'reply',
+            text: 'Yes',
+            postback_data: 'question_1_yes'
+          }
+        ]
+      },
+      opts: {
+        rcs: {
+          card_orientation: 'VERTICAL',
+          image_alignment: 'LEFT'
+        }
+      }
+    )
+
+    assert_equal expected, message.data
+  end
+
+  def test_rcs_carousel_message
+    expected = {
+      channel: 'rcs',
+      message_type: 'carousel',
+      carousel: {
+        cards: [
+          {
+            title: 'Card Title 1',
+            text: 'Card Description 1',
+            media_url:  'https://example.com/image1.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'Yes',
+                postback_data: 'question_1_yes'
+              }
+            ]
+          },
+          {
+            title: 'Card Title 2',
+            text: 'Card Description 2',
+            media_url:  'https://example.com/image2.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'No',
+                postback_data: 'question_1_no'
+              }
+            ]
+          }
+        ]
+      },
+      rcs: {
+        card_width: 'SMALL'
+      }
+    }
+
+    message = Vonage::Messaging::Channels::RCS.new(
+      type: 'carousel',
+      message: {
+        cards: [
+          {
+            title: 'Card Title 1',
+            text: 'Card Description 1',
+            media_url:  'https://example.com/image1.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'Yes',
+                postback_data: 'question_1_yes'
+              }
+            ]
+          },
+          {
+            title: 'Card Title 2',
+            text: 'Card Description 2',
+            media_url:  'https://example.com/image2.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'No',
+                postback_data: 'question_1_no'
+              }
+            ]
+          }
+        ]
+      },
+      opts: {
+        rcs: {
+          card_width: 'SMALL'
+        }
+      }
+    )
+
+    assert_equal expected, message.data
+  end
+
+  def test_rcs_carousel_message_with_suggestions
+    expected = {
+      channel: 'rcs',
+      message_type: 'carousel',
+      carousel: {
+        cards: [
+          {
+            title: 'Card Title 1',
+            text: 'Card Description 1',
+            media_url:  'https://example.com/image1.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'Yes',
+                postback_data: 'question_1_yes'
+              }
+            ]
+          },
+          {
+            title: 'Card Title 2',
+            text: 'Card Description 2',
+            media_url:  'https://example.com/image2.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'No',
+                postback_data: 'question_1_no'
+              }
+            ]
+          }
+        ]
+      },
+      rcs: {
+        card_width: 'SMALL'
+      },
+      suggestions: [
+        {
+          type: 'reply',
+          text: 'Maybe',
+          postback_data: 'question_1_maybe'
+        }
+      ]
+    }
+
+    message = Vonage::Messaging::Channels::RCS.new(
+      type: 'carousel',
+      message: {
+        cards: [
+          {
+            title: 'Card Title 1',
+            text: 'Card Description 1',
+            media_url:  'https://example.com/image1.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'Yes',
+                postback_data: 'question_1_yes'
+              }
+            ]
+          },
+          {
+            title: 'Card Title 2',
+            text: 'Card Description 2',
+            media_url:  'https://example.com/image2.jpg',
+            suggestions: [
+              {
+                type: 'reply',
+                text: 'No',
+                postback_data: 'question_1_no'
+              }
+            ]
+          }
+        ]
+      },
+      opts: {
+        rcs: {
+          card_width: 'SMALL'
+        },
+        suggestions: [
+          {
+            type: 'reply',
+            text: 'Maybe',
+            postback_data: 'question_1_maybe'
+          }
+        ]
       }
     )
 

--- a/test/vonage/messaging/channels/rcs_test.rb
+++ b/test/vonage/messaging/channels/rcs_test.rb
@@ -30,7 +30,10 @@ class Vonage::Messaging::Channels::RCSTest < Vonage::Test
       text: 'Hello world!',
       ttl: 600,
       client_ref: "abc123",
-      webhook_url: "https://example.com/status"
+      webhook_url: "https://example.com/status",
+      rcs: {
+        category: 'transaction'
+      }
     }
 
     message = Vonage::Messaging::Channels::RCS.new(
@@ -39,7 +42,10 @@ class Vonage::Messaging::Channels::RCSTest < Vonage::Test
       opts: {
         ttl: 600,
         client_ref: "abc123",
-        webhook_url: "https://example.com/status"
+        webhook_url: "https://example.com/status",
+        rcs: {
+          category: 'transaction'
+        }
       }
     )
 

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -43,7 +43,7 @@ class Vonage::MessagingTest < Vonage::Test
     assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
   end
 
-  def test_send_method_for_sms_with_optional_params
+  def test_send_method_with_optional_params
     request_params = {
       to: "447700900000",
       from: "447700900001",

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -43,6 +43,43 @@ class Vonage::MessagingTest < Vonage::Test
     assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
   end
 
+  def test_send_method_for_sms_with_optional_params
+    request_params = {
+      to: "447700900000",
+      from: "447700900001",
+      channel: "sms",
+      message_type: "text",
+      text: "Hello world!",
+      client_ref: "1234",
+      ttl: 900000,
+      trusted_sender: true,
+      sms: {
+        encoding_type: "text",
+        content_id: "1107457532145798767",
+        entity_id: "1101456324675322134",
+        pool_id: "abc123"
+      }
+    }
+
+    opts = {
+      client_ref: "1234",
+      ttl: 900000,
+      trusted_sender: true,
+      sms: {
+        encoding_type: "text",
+        content_id: "1107457532145798767",
+        entity_id: "1101456324675322134",
+        pool_id: "abc123"
+      }
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: request_params)).to_return(response)
+
+    message = messaging.sms(message: "Hello world!", opts: opts)
+
+    assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
+  end
+
   def test_send_method_without_to
     assert_raises(ArgumentError) { messaging.send(from: "447700900001", channel: 'sms', message_type: 'text', text: "Hello world!") }
   end

--- a/test/vonage/sms_test.rb
+++ b/test/vonage/sms_test.rb
@@ -52,6 +52,15 @@ class Vonage::SMSTest < Vonage::Test
     assert_kind_of Vonage::Response, error.response
   end
 
+  def test_send_method_with_trusted_number_param
+    method_params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!', trusted_number: true}
+    request_params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!', 'trusted-number' => true}
+
+    stub_request(:post, uri).with(headers: headers, body: request_params.merge(api_key_and_secret)).to_return(response, error_response)
+
+    assert_kind_of Vonage::Response, sms.send(method_params)
+  end
+
   def test_mapping_underscored_keys_to_hyphenated_string_keys
     params = {'status-report-req' => '1', 'text' => 'Hey'}
 


### PR DESCRIPTION
This PR makes updates to the Messages API implementation. Specifically it:

- Update the SMS channel to support the `pool_id` and `trusted_number` params
- Updates the MMS channel to add support for the `text`, `file`, and `content` message types
- Updates the RCS channel to add support for the `card` and `carousel` message types as well as using `suggestions` in the `text` message type.