### PR TITLE
feat: Voice Updates Q3 2025

### DIFF
--- a/lib/vonage/voice/actions/connect.rb
+++ b/lib/vonage/voice/actions/connect.rb
@@ -67,7 +67,9 @@ module Vonage
         raise ClientError.new("Expected 'uri' value to be a valid URI") unless URI.parse(endpoint[:uri]).kind_of?(URI::Generic)
         raise ClientError.new("Expected 'content-type' parameter to be either 'audio/116;rate=16000' or 'audio/116;rate=8000") unless endpoint[:'content-type'] == 'audio/116;rate=16000' || endpoint[:'content-type'] == 'audio/116;rate=8000'
       when 'sip'
-        raise ClientError.new("Expected 'uri' value to be a valid URI") unless URI.parse(endpoint[:uri]).kind_of?(URI::Generic)
+        raise ClientError.new("Expected 'uri' value to be a valid URI") unless URI.parse(endpoint[:uri]).kind_of?(URI::Generic) if endpoint[:uri]
+        raise ClientError.new("`uri` must not be combined with `user` and `domain`") if endpoint[:uri] && (endpoint[:user] || endpoint[:domain])
+        raise ClientError.new("You must provide both `user` and `domain`") if (endpoint[:user] && !endpoint[:domain]) || (endpoint[:domain] && !endpoint[:user])
       end
     end
 
@@ -208,10 +210,12 @@ module Vonage
 
     def sip_endpoint(endpoint_attrs)
       hash = {
-        type: 'sip',
-        uri: endpoint_attrs[:uri]
+        type: 'sip'
       }
 
+      hash.merge!(uri: endpoint_attrs[:uri]) if endpoint_attrs[:uri]
+      hash.merge!(user: endpoint_attrs[:user]) if endpoint_attrs[:user]
+      hash.merge!(domain: endpoint_attrs[:domain]) if endpoint_attrs[:domain]
       hash.merge!(headers: endpoint_attrs[:headers]) if endpoint_attrs[:headers]
       hash.merge!(standardHeaders: endpoint_attrs[:standardHeaders]) if endpoint_attrs[:standardHeaders]
 

--- a/lib/vonage/voice/actions/stream.rb
+++ b/lib/vonage/voice/actions/stream.rb
@@ -3,16 +3,13 @@
 
 module Vonage
   class Voice::Actions::Stream
-    attr_accessor :streamUrl, :level, :bargeIn, :loop, :eventOnCompletion, :eventUrl, :eventMethod
+    attr_accessor :streamUrl, :level, :bargeIn, :loop
 
     def initialize(attributes = {})
       @streamUrl = attributes.fetch(:streamUrl)
       @level = attributes.fetch(:level, nil)
       @bargeIn = attributes.fetch(:bargeIn, nil)
       @loop = attributes.fetch(:loop, nil)
-      @eventOnCompletion = attributes.fetch(:eventOnCompletion, nil)
-      @eventUrl = attributes.fetch(:eventUrl, nil)
-      @eventMethod = attributes.fetch(:eventMethod, nil)
 
       after_initialize!
     end
@@ -30,18 +27,6 @@ module Vonage
 
       if self.loop
         verify_loop
-      end
-
-      if self.eventOnCompletion || self.eventOnCompletion == false
-        verify_event_on_completion
-      end
-
-      if self.eventUrl
-        verify_event_url
-      end
-
-      if self.eventMethod
-        verify_event_method
       end
     end
 
@@ -69,28 +54,6 @@ module Vonage
       raise ClientError.new("Expected 'loop' value to be either 0 or a positive integer") unless self.loop >= 0
     end
 
-    def verify_event_on_completion
-      raise ClientError.new("Expected 'eventOnCompletion' value to be a Boolean") unless self.eventOnCompletion == true || self.eventOnCompletion == false
-    end
-
-    def verify_event_url
-      unless self.eventUrl.is_a?(Array) && self.eventUrl.length == 1 && self.eventUrl[0].is_a?(String)
-        raise ClientError.new("Expected 'eventUrl' parameter to be an Array containing a single string item")
-      end
-
-      uri = URI.parse(self.eventUrl[0])
-
-      raise ClientError.new("Invalid 'eventUrl' value, array must contain a valid URL") unless uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)
-
-      self.eventUrl
-    end
-
-    def verify_event_method
-      valid_methods = ['GET', 'POST']
-
-      raise ClientError.new("Invalid 'eventMethod' value. must be either: 'GET' or 'POST'") unless valid_methods.include?(self.eventMethod.upcase)
-    end
-
     def action
       create_stream!(self)
     end
@@ -106,9 +69,6 @@ module Vonage
       ncco[0].merge!(level: builder.level) if builder.level
       ncco[0].merge!(bargeIn: builder.bargeIn) if (builder.bargeIn || builder.bargeIn == false)
       ncco[0].merge!(loop: builder.loop) if builder.loop
-      ncco[0].merge!(eventOnCompletion: builder.eventOnCompletion) if (builder.eventOnCompletion || builder.eventOnCompletion == false)
-      ncco[0].merge!(eventUrl: builder.eventUrl) if builder.eventUrl
-      ncco[0].merge!(eventMethod: builder.eventMethod) if builder.eventMethod
 
       ncco
     end

--- a/lib/vonage/voice/actions/talk.rb
+++ b/lib/vonage/voice/actions/talk.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 module Vonage
   class Voice::Actions::Talk
-    attr_accessor :text, :bargeIn, :loop, :level, :language, :style, :premium, :eventOnCompletion, :eventUrl, :eventMethod
+    attr_accessor :text, :bargeIn, :loop, :level, :language, :style, :premium
 
     def initialize(attributes= {})
       @text = attributes.fetch(:text)
@@ -12,9 +12,6 @@ module Vonage
       @language = attributes.fetch(:language, nil)
       @style = attributes.fetch(:style, nil)
       @premium = attributes.fetch(:premium, nil)
-      @eventOnCompletion = attributes.fetch(:eventOnCompletion, nil)
-      @eventUrl = attributes.fetch(:eventUrl, nil)
-      @eventMethod = attributes.fetch(:eventMethod, nil)
 
       after_initialize!
     end
@@ -39,18 +36,6 @@ module Vonage
       if self.premium || self.premium == false
         verify_premium
       end
-
-      if self.eventOnCompletion || self.eventOnCompletion == false
-        verify_event_on_completion
-      end
-
-      if self.eventUrl
-        verify_event_url
-      end
-
-      if self.eventMethod
-        verify_event_method
-      end
     end
 
     def verify_barge_in
@@ -73,28 +58,6 @@ module Vonage
       raise ClientError.new("Expected 'premium' value to be a Boolean") unless self.premium == true || self.premium == false
     end
 
-    def verify_event_on_completion
-      raise ClientError.new("Expected 'eventOnCompletion' value to be a Boolean") unless self.eventOnCompletion == true || self.eventOnCompletion == false
-    end
-
-    def verify_event_url
-      unless self.eventUrl.is_a?(Array) && self.eventUrl.length == 1 && self.eventUrl[0].is_a?(String)
-        raise ClientError.new("Expected 'eventUrl' parameter to be an Array containing a single string item")
-      end
-
-      uri = URI.parse(self.eventUrl[0])
-
-      raise ClientError.new("Invalid 'eventUrl' value, array must contain a valid URL") unless uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)
-
-      self.eventUrl
-    end
-
-    def verify_event_method
-      valid_methods = ['GET', 'POST']
-
-      raise ClientError.new("Invalid 'eventMethod' value. must be either: 'GET' or 'POST'") unless valid_methods.include?(self.eventMethod.upcase)
-    end
-
     def action
       create_talk!(self)
     end
@@ -113,9 +76,6 @@ module Vonage
       ncco[0].merge!(language: builder.language) if builder.language
       ncco[0].merge!(style: builder.style) if builder.style
       ncco[0].merge!(premium: builder.premium) if (builder.bargeIn || builder.bargeIn == false)
-      ncco[0].merge!(eventOnCompletion: builder.eventOnCompletion) if (builder.eventOnCompletion || builder.eventOnCompletion == false)
-      ncco[0].merge!(eventUrl: builder.eventUrl) if builder.eventUrl
-      ncco[0].merge!(eventMethod: builder.eventMethod) if builder.eventMethod
 
       ncco
     end

--- a/test/vonage/voice/actions/connect_test.rb
+++ b/test/vonage/voice/actions/connect_test.rb
@@ -30,6 +30,44 @@ class Vonage::Voice::Actions::ConnectTest < Vonage::Test
     assert_equal expected, connect.create_endpoint(connect)
   end
 
+  def test_create_endpoint_with_sip_uri
+    expected = { type: 'sip', uri: 'sip:joe@domain.com' }
+    connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'sip', uri: 'sip:joe@domain.com' })
+
+    assert_equal expected, connect.create_endpoint(connect)
+  end
+
+  def test_create_endpoint_with_sip_user_and_domain
+    expected = { type: 'sip', user: 'joe', domain: 'domain.com' }
+    connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'sip', user: 'joe', domain: 'domain.com' })
+
+    assert_equal expected, connect.create_endpoint(connect)
+  end
+
+  def test_verify_endpoint_with_mutually_exclusive_sip_params
+    endpoint = { type: 'sip', uri: 'sip:joe@domain.com', user: 'joe', domain: 'domain.com' }
+
+    exception = assert_raises { Vonage::Voice::Actions::Connect.new(endpoint: endpoint) }
+
+    assert_match "`uri` must not be combined with `user` and `domain`", exception.message
+  end
+
+  def test_verify_endpoint_with_user_but_no_domain_sip_params
+    endpoint = { type: 'sip', user: 'joe' }
+
+    exception = assert_raises { Vonage::Voice::Actions::Connect.new(endpoint: endpoint) }
+
+    assert_match "You must provide both `user` and `domain`", exception.message
+  end
+
+  def test_verify_endpoint_with_domain_but_no_user_sip_params
+    endpoint = { type: 'sip', domain: 'domain.com' }
+
+    exception = assert_raises { Vonage::Voice::Actions::Connect.new(endpoint: endpoint) }
+
+    assert_match "You must provide both `user` and `domain`", exception.message
+  end
+
   def test_verify_endpoint_with_invalid_phone_number
     endpoint = { type: 'phone', number: 'abcd' }
 

--- a/test/vonage/voice/actions/stream_test.rb
+++ b/test/vonage/voice/actions/stream_test.rb
@@ -25,12 +25,7 @@ class Vonage::Voice::Actions::StreamTest < Vonage::Test
         ],
         level: 0.5,
         bargeIn: true,
-        loop: 2,
-        eventOnCompletion: true,
-        eventUrl: [
-          'https://example.com/event'
-        ],
-        eventMethod: 'GET'
+        loop: 2
       }
     ]
 
@@ -40,12 +35,7 @@ class Vonage::Voice::Actions::StreamTest < Vonage::Test
         ],
         level: 0.5,
         bargeIn: true,
-        loop: 2,
-        eventOnCompletion: true,
-        eventUrl: [
-          'https://example.com/event'
-        ],
-        eventMethod: 'GET'
+        loop: 2
     )
 
     assert_equal expected, stream.create_stream!(stream)
@@ -85,29 +75,5 @@ class Vonage::Voice::Actions::StreamTest < Vonage::Test
     exception = assert_raises { Vonage::Voice::Actions::Stream.new(streamUrl: [ 'https://example.com/example.mp3' ], loop: -1) }
 
     assert_match "Expected 'loop' value to be either 0 or a positive integer", exception.message
-  end
-
-  def test_stream_with_invalid_event_on_completion_value
-    exception = assert_raises { Vonage::Voice::Actions::Stream.new(streamUrl: [ 'https://example.com/example.mp3' ], eventOnCompletion: 'true') }
-
-    assert_match "Expected 'eventOnCompletion' value to be a Boolean", exception.message
-  end
-
-  def test_stream_with_invalid_event_url_type
-    exception = assert_raises { Vonage::Voice::Actions::Stream.new(streamUrl: [ 'https://example.com/example.mp3' ], eventUrl: 'https://example.com/event') }
-
-    assert_match "Expected 'eventUrl' parameter to be an Array containing a single string item", exception.message
-  end
-
-  def test_stream_with_invalid_event_url
-    exception = assert_raises { Vonage::Voice::Actions::Stream.new(streamUrl: [ 'https://example.com/example.mp3' ], eventUrl: ['foo.bar']) }
-
-    assert_match "Invalid 'eventUrl' value, array must contain a valid URL", exception.message
-  end
-
-  def test_stream_with_invalid_event_method
-    exception = assert_raises { Vonage::Voice::Actions::Stream.new(streamUrl: [ 'https://example.com/example.mp3' ], eventMethod: 'PATCH') }
-
-    assert_match "Invalid 'eventMethod' value. must be either: 'GET' or 'POST'", exception.message
   end
 end

--- a/test/vonage/voice/actions/talk_test.rb
+++ b/test/vonage/voice/actions/talk_test.rb
@@ -26,12 +26,7 @@ class Vonage::Voice::Actions::TalkTest < Vonage::Test
         level: 0.5,
         language: 'en-GB',
         style: 1,
-        premium: true,
-        eventOnCompletion: true,
-        eventUrl: [
-          'https://example.com/event'
-        ],
-        eventMethod: 'GET'
+        premium: true
       }
     ]
 
@@ -42,12 +37,7 @@ class Vonage::Voice::Actions::TalkTest < Vonage::Test
       level: 0.5,
       language: 'en-GB',
       style: 1,
-      premium: true,
-      eventOnCompletion: true,
-      eventUrl: [
-        'https://example.com/event'
-      ],
-      eventMethod: 'GET'
+      premium: true
     )
 
     assert_equal expected, talk.create_talk!(talk)
@@ -81,29 +71,5 @@ class Vonage::Voice::Actions::TalkTest < Vonage::Test
     exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', premium: 'foo' }) }
 
     assert_match "Expected 'premium' value to be a Boolean", exception.message
-  end
-
-  def test_talk_with_invalid_event_on_completion_value
-    exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', eventOnCompletion: 'true' }) }
-
-    assert_match "Expected 'eventOnCompletion' value to be a Boolean", exception.message
-  end
-
-  def test_talk_with_invalid_event_url_type
-    exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', eventUrl: 'https://example.com/event' }) }
-
-    assert_match "Expected 'eventUrl' parameter to be an Array containing a single string item", exception.message
-  end
-
-  def test_talk_with_invalid_event_url
-    exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', eventUrl: ['foo.bar'] }) }
-
-    assert_match "Invalid 'eventUrl' value, array must contain a valid URL", exception.message
-  end
-
-  def test_talk_with_invalid_event_method
-    exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', eventMethod: 'PATCH' }) }
-
-    assert_match "Invalid 'eventMethod' value. must be either: 'GET' or 'POST'", exception.message
   end
 end


### PR DESCRIPTION
This PR updates the Voice API implementation to:

- Add support for the `user` and `domain` params in a `sip` action of a `connect` NCCO
- Remove the `eventOnCompletion`, `eventUrl`, and `eventMethod` params from the `stream` and `talk` NCCOs