### PR TITLE
feat: Number Insight Updates Q3 2025

### DIFF
--- a/lib/vonage/client.rb
+++ b/lib/vonage/client.rb
@@ -71,7 +71,7 @@ module Vonage
     end
 
     # @return [Meetings]
-    #
+    # @deprecated
     sig { returns(T.nilable(Vonage::Meetings)) }
     def meetings
       @meetings ||= T.let(Meetings.new(config), T.nilable(Vonage::Meetings))
@@ -113,7 +113,7 @@ module Vonage
     end
 
     # @return [NumberInsight2]
-    #
+    # @deprecated
     sig { returns(T.nilable(Vonage::NumberInsight2)) }
     def number_insight_2
       @number_insight_2 ||= T.let(NumberInsight2.new(config), T.nilable(Vonage::NumberInsight2))
@@ -134,7 +134,7 @@ module Vonage
     end
 
     # @return [ProactiveConnect]
-    #
+    # @deprecated
     sig { returns(T.nilable(Vonage::ProactiveConnect)) }
     def proactive_connect
       @proactive_connect ||= T.let(ProactiveConnect.new(config), T.nilable(Vonage::ProactiveConnect))

--- a/lib/vonage/number_insight.rb
+++ b/lib/vonage/number_insight.rb
@@ -3,6 +3,7 @@
 
 module Vonage
   class NumberInsight < Namespace
+    self.authentication = Basic
     # Provides basic number insight information about a number.
     #
     # @example

--- a/lib/vonage/number_insight_2.rb
+++ b/lib/vonage/number_insight_2.rb
@@ -9,25 +9,10 @@ module Vonage
 
     self.request_body = JSON
 
-    # Make fraud check requests with a phone number by looking up fraud score and/or by checking sim swap status.
-    #
-    # @example
-    #   response = client.number_insight_2.fraud_check(type: 'phone', phone: '447900000000', insights: ['fraud_score'])
-    #
-    # @param [required, String] :type The type of number to check.
-    #   Accepted value is “phone” when a phone number is provided.
-    #
-    # @param [required, String] :phone A single phone number that you need insight about in the E.164 format.
-    #
-    # @param [required, Array] :insights An array of strings indicating the fraud check insights required for the number.
-    #   Must be least one of: `fraud_score`, `sim_swap`
-    #
-    # @return [Response]
-    #
-    # @see https://developer.vonage.com/en/api/number-insight.v2#fraud_check
-    #
+   # @deprecated
     sig { params(type: String, phone: String, insights: T::Array[String]).returns(Vonage::Response) }
     def fraud_check(type:, phone:, insights:)
+      logger.info('This method is deprecated and will be removed in a future release.')
       raise ArgumentError.new("`insights` must not be an empty") if insights.empty?
 
       request('/v2/ni', params: {type: type, phone: phone, insights: insights}, type: Post)

--- a/test/vonage/number_insight_test.rb
+++ b/test/vonage/number_insight_test.rb
@@ -10,10 +10,6 @@ class Vonage::NumberInsightTest < Vonage::Test
     {number: msisdn}
   end
 
-  def query
-    params.merge(api_key_and_secret)
-  end
-
   def response
     {
       headers: response_headers,
@@ -31,7 +27,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_basic_method
     uri = 'https://api.nexmo.com/ni/basic/json'
 
-    stub_request(:get, uri).with(query: query).to_return(response, error_response)
+    stub_request(:get, uri).with(query: params).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.basic(params)
 
@@ -46,7 +42,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_standard_method
     uri = 'https://api.nexmo.com/ni/standard/json'
 
-    stub_request(:get, uri).with(query: query).to_return(response, error_response)
+    stub_request(:get, uri).with(query: params).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.standard(params)
 
@@ -61,7 +57,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_advanced_method
     uri = 'https://api.nexmo.com/ni/advanced/json'
 
-    stub_request(:get, uri).with(query: query).to_return(response, error_response)
+    stub_request(:get, uri).with(query: params).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.advanced(params)
 
@@ -76,7 +72,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_advanced_async_method
     uri = 'https://api.nexmo.com/ni/advanced/async/json'
 
-    stub_request(:get, uri).with(query: query).to_return(response, error_response)
+    stub_request(:get, uri).with(query: params).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.advanced_async(params)
 


### PR DESCRIPTION
This PR updates the Number Insight API implementation to:

- Deprecate NI v2
- Update NI v1 to use Basic Auth