### PR TITLE
feat: Video Updates Q4 2025

### DIFF
--- a/lib/vonage/keys.rb
+++ b/lib/vonage/keys.rb
@@ -41,7 +41,9 @@ module Vonage
         'hashed_phone_number',
         'max_age',
         'max_bitrate',
-        'quantization_parameter'
+        'quantization_parameter',
+        'has_transcription',
+        'transcription_properties'
       ]
       hash.transform_keys do |k|
         if exceptions.include?(k.to_s)

--- a/lib/vonage/video.rb
+++ b/lib/vonage/video.rb
@@ -107,12 +107,6 @@ module Vonage
       @streams ||= Streams.new(@config)
     end
 
-    # @return [Streams]
-    #
-    def streams
-      @streams ||= Streams.new(@config)
-    end
-
     # @return [Connections]
     #
     def connections

--- a/lib/vonage/video.rb
+++ b/lib/vonage/video.rb
@@ -107,6 +107,18 @@ module Vonage
       @streams ||= Streams.new(@config)
     end
 
+    # @return [Streams]
+    #
+    def streams
+      @streams ||= Streams.new(@config)
+    end
+
+    # @return [Connections]
+    #
+    def connections
+      @connections ||= Connections.new(@config)
+    end
+
     # @return [Captions]
     #
     def captions

--- a/lib/vonage/video/archives.rb
+++ b/lib/vonage/video/archives.rb
@@ -71,6 +71,14 @@ module Vonage
     #
     # @option layout [optional, String] :screenshareType
     #
+    # @param [optional, Boolean] :has_transcription
+    #
+    # @param [optional, Hash] :transcription_properties
+    #
+    # @option transcription_properties [optional, String] :primaryLanguageCode
+    #
+    # @option transcription_properties [optional, Boolean] :hasSummary
+    #
     # @return [Response]
     #
     # @see TODO: add docs link

--- a/lib/vonage/video/connections.rb
+++ b/lib/vonage/video/connections.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+module Vonage
+  class Video::Connections < Namespace
+
+    self.authentication = BearerToken
+
+    self.request_body = JSON
+
+    self.host = :video_host
+
+    # Get a list of connections for a specified session.
+    #
+    # @param [optional, String] :application_id (Required unless already set at Client instantiation or set in ENV)
+    #
+    # @param [required, String] :session_id
+    #
+    # TODO: add auto_advance option
+    #
+    # @return [ListResponse]
+    #
+    # @see TODO: add docs link
+    #
+    def list(session_id:)
+      request('/v2/project/' + @config.application_id + '/session/' + session_id + '/connection', response_class: ListResponse)
+    end
+  end
+end

--- a/lib/vonage/video/connections/list_response.rb
+++ b/lib/vonage/video/connections/list_response.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Vonage::Video::Connections::ListResponse < Vonage::Response
+  include Enumerable
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    @entity.items.each { |item| yield item }
+  end
+end

--- a/test/vonage/video/archives_test.rb
+++ b/test/vonage/video/archives_test.rb
@@ -45,7 +45,9 @@ class Vonage::Video::ArchivesTest < Vonage::Test
       resolution: '640x480',
       streamMode: 'auto',
       maxBitrate: 200000,
-      quantizationParameter: 40
+      quantizationParameter: 40,
+      hasTranscription: true,
+      transcriptionProperties: {primaryLanguageCode: 'en-US', hasSummary: true}
     }
 
     stub_request(:post, uri).with(body: request_params).to_return(response)
@@ -55,7 +57,9 @@ class Vonage::Video::ArchivesTest < Vonage::Test
       resolution: '640x480',
       stream_mode: 'auto',
       max_bitrate: 200000,
-      quantization_parameter: 40
+      quantization_parameter: 40,
+      has_transcription: true,
+      transcription_properties: {primaryLanguageCode: 'en-US', hasSummary: true}
     )
   end
 

--- a/test/vonage/video/connections_test.rb
+++ b/test/vonage/video/connections_test.rb
@@ -1,0 +1,21 @@
+# typed: false
+require_relative '../test'
+
+class Vonage::Video::ConnectionsTest < Vonage::Test
+  def connections
+    Vonage::Video::Connections.new(config)
+  end
+
+  def uri
+    'https://video.api.vonage.com/v2/project/' + application_id + '/session/' + video_session_id + '/connection'
+  end
+
+  def test_list_method
+    stub_request(:get, uri).to_return(video_list_response)
+
+    connections_list = connections.list(session_id: video_session_id)
+
+    assert_kind_of Vonage::Video::Connections::ListResponse, connections_list
+    connections_list.each { |connection| assert_kind_of Vonage::Entity, connection }
+  end
+end

--- a/test/vonage/video_test.rb
+++ b/test/vonage/video_test.rb
@@ -158,6 +158,10 @@ class Vonage::VideoTest < Vonage::Test
     assert_kind_of Vonage::Video::Streams, video.streams
   end
 
+  def test_connections_method
+    assert_kind_of Vonage::Video::Connections, video.connections
+  end
+
   def test_archives_method
     assert_kind_of Vonage::Video::Archives, video.archives
   end


### PR DESCRIPTION
This PR updates the implementation for the Video API. Specifically it:

- Adds support for the `hasTranscription` and `transcriptionProperties` params to the `Archives#start` method
- Implements a new `Connections` class with a `list` method
- Adds/updates unit tests to cover the above changes