### PR TITLE
feat: Change Query Params Auth to Basic Auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.33.0
+
+* Updates SMS API, Verify v1 API, Number Insight v1 API, Account API, and Conversion API to support Basic Authentication. See [#343](https://github.com/Vonage/vonage-ruby-sdk/pull/343)
+
 # 7.32.0
 
 * Updates Video API implementation to add support for support for the `hasTranscription` and `transcriptionProperties` parameters and implement list connections functionality. See [#340](https://github.com/Vonage/vonage-ruby-sdk/pull/340)

--- a/lib/vonage/account.rb
+++ b/lib/vonage/account.rb
@@ -6,6 +6,8 @@ module Vonage
     extend T::Sig
     include Keys
 
+    self.authentication = Basic
+
     self.host = :rest_host
 
     # Retrieve your account balance.

--- a/lib/vonage/basic_and_signature.rb
+++ b/lib/vonage/basic_and_signature.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+module Vonage
+  class BasicAndSignature < AbstractAuthentication
+    def update(object, data)
+      if @config.authentication_preference == :signature
+        return unless object.is_a?(Hash)
+        
+        object['api_key'] = T.must(@config).api_key
+        object['timestamp'] =Time.now.to_i.to_s
+        signature = Signature.new(@config).generate(object)
+        object[:sig] = signature
+      else
+        return unless object.is_a?(Net::HTTPRequest)
+
+        object.basic_auth(@config.api_key, @config.api_secret)
+      end
+    end
+  end
+
+  private_constant :Basic
+end

--- a/lib/vonage/config.rb
+++ b/lib/vonage/config.rb
@@ -109,6 +109,9 @@ module Vonage
     sig { returns(T.nilable(String)) }
     attr_accessor :app_version
 
+    sig { returns(T.nilable(Symbol)) }
+    attr_accessor :authentication_preference
+
     # Returns the value of attribute http.
     #
     # @return [Vonage::HTTP::Options]

--- a/lib/vonage/conversions.rb
+++ b/lib/vonage/conversions.rb
@@ -6,6 +6,8 @@ module Vonage
     extend T::Sig
     include Keys
 
+    self.authentication = BasicAndSignature
+
     sig { params(params: T::Hash[Symbol, T.untyped]).returns(Vonage::Response) }
     def track_sms(params)
       request('/conversions/sms', params: hyphenate(params), type: Post)

--- a/lib/vonage/signature.rb
+++ b/lib/vonage/signature.rb
@@ -61,7 +61,7 @@ module Vonage
     private
 
     def digest(params, signature_secret, signature_method)
-      digest_string = params.sort.map { |k, v| "&#{k}=#{v.tr('&=', '_')}" }.join
+      digest_string = params.sort.map { |k, v| "&#{k}=#{v.to_s.tr('&=', '_')}" }.join
 
       case signature_method
       when 'md5', 'sha1', 'sha256', 'sha512'

--- a/lib/vonage/signature.rb
+++ b/lib/vonage/signature.rb
@@ -10,6 +10,28 @@ module Vonage
       @config = config
     end
 
+    # Generate a request signature.
+    #
+    # @example
+    #   client = Vonage::Client.new
+    #   client.config.signature_secret = 'secret'
+    #   client.config.signature_method = 'sha512'
+    #   params = {
+    #     'to' => '447900000000',
+    #     'from' => '447900000001',
+    #     'text' => 'Hello World',
+    #     'timestamp' => '1385047698'
+    #   }
+    #
+    #   sig = client.signature.generate(params)
+    #
+    # @param [Hash] params
+    #
+    # @see https://developer.nexmo.com/concepts/guides/signing-messages
+    def generate(params, signature_secret: @config.signature_secret, signature_method: @config.signature_method)
+      digest(params, signature_secret, signature_method)
+    end
+    
     # Check webhook request signature.
     #
     # @example

--- a/lib/vonage/signature.rb
+++ b/lib/vonage/signature.rb
@@ -17,6 +17,7 @@ module Vonage
     #   client.config.signature_secret = 'secret'
     #   client.config.signature_method = 'sha512'
     #   params = {
+    #     'api_key' => 'abc123',
     #     'to' => '447900000000',
     #     'from' => '447900000001',
     #     'text' => 'Hello World',

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -6,6 +6,8 @@ module Vonage
     extend T::Sig
     include Keys
 
+    self.authentication = BasicAndSignature
+
     self.host = :rest_host
 
     # Send an outbound SMS from your Vonage account.

--- a/lib/vonage/verify.rb
+++ b/lib/vonage/verify.rb
@@ -8,6 +8,8 @@ module Vonage
 
     private :http_request
 
+    self.authentication = Basic
+
     # Generate and send a PIN to your user.
     #
     # @note You can make a maximum of one Verify request per second.

--- a/lib/vonage/version.rb
+++ b/lib/vonage/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Vonage
-  VERSION = '7.32.0'
+  VERSION = '7.33.0'
 end

--- a/test/vonage/account_test.rb
+++ b/test/vonage/account_test.rb
@@ -6,6 +6,10 @@ class Vonage::AccountTest < Vonage::Test
     Vonage::Account.new(config)
   end
 
+  def authorization
+    basic_authorization
+  end
+
   def test_balance_method
     uri = 'https://rest.nexmo.com/account/get-balance'
 

--- a/test/vonage/account_test.rb
+++ b/test/vonage/account_test.rb
@@ -9,7 +9,7 @@ class Vonage::AccountTest < Vonage::Test
   def test_balance_method
     uri = 'https://rest.nexmo.com/account/get-balance'
 
-    stub_request(:get, uri).with(query: api_key_and_secret).to_return(response)
+    stub_request(:get, uri).with(request).to_return(response)
 
     assert_kind_of Vonage::Response, account.balance
   end
@@ -21,7 +21,7 @@ class Vonage::AccountTest < Vonage::Test
 
     params = {'moCallBackUrl' => callback_url}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response)
 
     assert_kind_of Vonage::Response, account.update(mo_call_back_url: callback_url)
   end
@@ -31,7 +31,7 @@ class Vonage::AccountTest < Vonage::Test
 
     params = {trx: '00X123456Y7890123Z'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response)
 
     assert_kind_of Vonage::Response, account.topup(params)
   end

--- a/test/vonage/conversions_test.rb
+++ b/test/vonage/conversions_test.rb
@@ -6,6 +6,21 @@ class Vonage::ConversionsTest < Vonage::Test
     Vonage::Conversions.new(config)
   end
 
+  def conversions_with_sig_auth
+    config = Vonage::Config.new.merge(
+      {
+        api_key: api_key,
+        signature_secret: signature_secret,
+        authentication_preference: :signature
+      }
+    )
+    Vonage::Conversions.new(config)
+  end
+
+  def authorization
+    basic_authorization
+  end
+
   def message_id
     'message-id'
   end
@@ -15,9 +30,21 @@ class Vonage::ConversionsTest < Vonage::Test
 
     params = {'message-id' => message_id, 'delivered' => 'true'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response)
 
     assert_kind_of Vonage::Response, conversions.track_sms(message_id: message_id, delivered: true)
+  end
+
+  def test_track_sms_method_with_signature_authenitication
+    uri = 'https://api.nexmo.com/conversions/sms'
+
+    params = {'message-id' => message_id, 'delivered' => 'true'}
+
+    stub_request(:post, uri).with(headers: headers, body: hash_including(params)) do |request|
+      request.body.include?('api_key=') && request.body.include?('timestamp=') && request.body.include?('sig=')
+    end.to_return(response)
+
+    assert_kind_of Vonage::Response, conversions_with_sig_auth.track_sms(message_id: message_id, delivered: true)
   end
 
   def test_track_voice_method
@@ -25,8 +52,20 @@ class Vonage::ConversionsTest < Vonage::Test
 
     params = {'message-id' => message_id, 'delivered' => 'true'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response)
 
     assert_kind_of Vonage::Response, conversions.track_voice(message_id: message_id, delivered: true)
+  end
+
+  def test_track_voice_method_with_signature_authenitication
+    uri = 'https://api.nexmo.com/conversions/voice'
+
+    params = {'message-id' => message_id, 'delivered' => 'true'}
+
+    stub_request(:post, uri).with(headers: headers, body: hash_including(params)) do |request|
+      request.body.include?('api_key=') && request.body.include?('timestamp=') && request.body.include?('sig=')
+    end.to_return(response)
+
+    assert_kind_of Vonage::Response, conversions_with_sig_auth.track_voice(message_id: message_id, delivered: true)
   end
 end

--- a/test/vonage/hosts_test.rb
+++ b/test/vonage/hosts_test.rb
@@ -31,7 +31,7 @@ class Vonage::HostsTest < Vonage::Test
 
     uri = %r{\Ahttps://#{rest_host}/}
 
-    stub_request(:get, uri).with(query: api_key_and_secret).to_return(response)
+    stub_request(:get, uri).with(request).to_return(response)
 
     assert_kind_of Vonage::Response, account.balance
   end

--- a/test/vonage/number_insight_test.rb
+++ b/test/vonage/number_insight_test.rb
@@ -6,6 +6,10 @@ class Vonage::NumberInsightTest < Vonage::Test
     Vonage::NumberInsight.new(config)
   end
 
+  def authorization
+    basic_authorization
+  end
+
   def params
     {number: msisdn}
   end
@@ -27,8 +31,8 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_basic_method
     uri = 'https://api.nexmo.com/ni/basic/json'
 
-    stub_request(:get, uri).with(query: params).to_return(response, error_response)
-
+    stub_request(:get, uri).with(request(query: params)).to_return(response, error_response)
+    
     assert_kind_of Vonage::Response, number_insight.basic(params)
 
     error = assert_raises Vonage::ServiceError do
@@ -42,7 +46,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_standard_method
     uri = 'https://api.nexmo.com/ni/standard/json'
 
-    stub_request(:get, uri).with(query: params).to_return(response, error_response)
+    stub_request(:get, uri).with(request(query: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.standard(params)
 
@@ -57,7 +61,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_advanced_method
     uri = 'https://api.nexmo.com/ni/advanced/json'
 
-    stub_request(:get, uri).with(query: params).to_return(response, error_response)
+    stub_request(:get, uri).with(request(query: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.advanced(params)
 
@@ -72,7 +76,7 @@ class Vonage::NumberInsightTest < Vonage::Test
   def test_advanced_async_method
     uri = 'https://api.nexmo.com/ni/advanced/async/json'
 
-    stub_request(:get, uri).with(query: params).to_return(response, error_response)
+    stub_request(:get, uri).with(request(query: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, number_insight.advanced_async(params)
 

--- a/test/vonage/signature_test.rb
+++ b/test/vonage/signature_test.rb
@@ -22,58 +22,78 @@ class Vonage::SignatureTest < Vonage::Test
     }
   end
 
-  def params_with_valid_signature_md5hash
-    params.merge('sig' => 'd2e7b1dc968737c5998ad624e02f90b7')
+  def valid_signature_md5hash
+    'd2e7b1dc968737c5998ad624e02f90b7'
   end
 
-  def params_with_valid_signature_md5
-    params.merge('sig' => 'DDEBD46008C2D4E93CCE578A332A52D5')
+  def valid_signature_md5
+    'DDEBD46008C2D4E93CCE578A332A52D5'
   end
 
-  def params_with_valid_signature_sha1
-    params.merge('sig' => '27D0D05C2876C7CB1720DBCDBA4D492E1E55C09A')
+  def valid_signature_sha1
+    '27D0D05C2876C7CB1720DBCDBA4D492E1E55C09A'
   end
 
-  def params_with_valid_signature_sha256
-    params.merge('sig' => 'DDB8397C2B90AAC7F3882D306475C9A5058C92322EEF43C92B298B6E0FC0D330')
+  def valid_signature_sha256
+    'DDB8397C2B90AAC7F3882D306475C9A5058C92322EEF43C92B298B6E0FC0D330'
   end
 
-  def params_with_valid_signature_sha512
-    params.merge('sig' => 'E0D3C650F8C9D1A5C174D10DDDBFB003E561F59B265616208B0487C5D819481CD3C311D59CF6165ECD1139622D5BA3A256C0D763AC4A9AD9144B5A426B94FE82')
+  def valid_signature_sha512
+    'E0D3C650F8C9D1A5C174D10DDDBFB003E561F59B265616208B0487C5D819481CD3C311D59CF6165ECD1139622D5BA3A256C0D763AC4A9AD9144B5A426B94FE82'
   end
 
-  def params_with_invalid_signature
-    params.merge('sig' => 'xxx')
+  def invalid_signature
+    'xxx'
+  end
+
+  def test_generate_method_with_md5hash
+    assert_equal signature.generate(params, signature_method: 'md5hash'), valid_signature_md5hash
+  end
+
+  def test_generate_method_with_md5hmac
+    assert_equal signature.generate(params, signature_method: 'md5'), valid_signature_md5
+  end
+
+  def test_generate_method_with_sha1
+    assert_equal signature.generate(params, signature_method: 'sha1'), valid_signature_sha1
+  end
+
+  def test_generate_method_with_sha256
+    assert_equal signature.generate(params, signature_method: 'sha256'), valid_signature_sha256
+  end
+
+  def test_generate_method_with_sha512
+    assert_equal signature.generate(params, signature_method: 'sha512'), valid_signature_sha512
   end
 
   def test_check_instance_method_with_md5hash
-    assert_equal signature.check(params_with_valid_signature_md5hash, signature_method: 'md5hash'), true
-    assert_equal signature.check(params_with_invalid_signature, signature_method: 'md5hash'), false
+    assert_equal signature.check(params.merge('sig' => valid_signature_md5hash), signature_method: 'md5hash'), true
+    assert_equal signature.check(params.merge('sig' => invalid_signature), signature_method: 'md5hash'), false
   end
 
   def test_check_instance_method_with_md5hmac
-    assert_equal signature.check(params_with_valid_signature_md5, signature_method: 'md5'), true
-    assert_equal signature.check(params_with_invalid_signature, signature_method: 'md5'), false
+    assert_equal signature.check(params.merge('sig' => valid_signature_md5), signature_method: 'md5'), true
+    assert_equal signature.check(params.merge('sig' => invalid_signature), signature_method: 'md5'), false
   end
 
   def test_check_instance_method_with_sha1
-    assert_equal signature.check(params_with_valid_signature_sha1, signature_method: 'sha1'), true
-    assert_equal signature.check(params_with_invalid_signature, signature_method: 'sha1'), false
+    assert_equal signature.check(params.merge('sig' => valid_signature_sha1), signature_method: 'sha1'), true
+    assert_equal signature.check(params.merge('sig' => invalid_signature), signature_method: 'sha1'), false
   end
 
   def test_check_instance_method_with_sha256
-    assert_equal signature.check(params_with_valid_signature_sha256, signature_method: 'sha256'), true
-    assert_equal signature.check(params_with_invalid_signature, signature_method: 'sha256'), false
+    assert_equal signature.check(params.merge('sig' => valid_signature_sha256), signature_method: 'sha256'), true
+    assert_equal signature.check(params.merge('sig' => invalid_signature), signature_method: 'sha256'), false
   end
 
   def test_check_instance_method_with_sha512
-    assert_equal signature.check(params_with_valid_signature_sha512, signature_method: 'sha512'), true
-    assert_equal signature.check(params_with_invalid_signature, signature_method: 'sha512'), false
+    assert_equal signature.check(params.merge('sig' => valid_signature_sha512), signature_method: 'sha512'), true
+    assert_equal signature.check(params.merge('sig' => invalid_signature), signature_method: 'sha512'), false
   end
 
   def test_check_instance_method_with_unknown_method
     exception = assert_raises ArgumentError do
-      signature.check(params_with_valid_signature_md5, signature_method: 'xxxx')
+      signature.check(params.merge('sig' => valid_signature_md5), signature_method: 'xxxx')
     end
 
     assert_equal 'Unknown signature algorithm: xxxx. Expected: md5hash, md5, sha1, sha256, or sha512.', exception.message

--- a/test/vonage/sms_test.rb
+++ b/test/vonage/sms_test.rb
@@ -6,8 +6,23 @@ class Vonage::SMSTest < Vonage::Test
     Vonage::SMS.new(config)
   end
 
+  def sms_with_sig_auth
+    config = Vonage::Config.new.merge(
+      {
+        api_key: api_key,
+        signature_secret: signature_secret,
+        authentication_preference: :signature
+      }
+    )
+    Vonage::SMS.new(config)
+  end
+
   def uri
     'https://rest.nexmo.com/sms/json'
+  end
+
+  def authorization
+    basic_authorization
   end
 
   def response
@@ -40,7 +55,7 @@ class Vonage::SMSTest < Vonage::Test
   def test_send_method
     params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, sms.send(params)
 
@@ -56,15 +71,32 @@ class Vonage::SMSTest < Vonage::Test
     method_params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!', trusted_number: true}
     request_params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!', 'trusted-number' => true}
 
-    stub_request(:post, uri).with(headers: headers, body: request_params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: request_params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, sms.send(method_params)
+  end
+
+  def test_send_method_with_signature_authenitication
+    params = {from: 'Ruby', to: msisdn, text: 'Hello from Ruby!'}
+
+    stub_request(:post, uri).with(headers: headers, body: hash_including(params)) do |request|
+      request.body.include?('api_key=') && request.body.include?('timestamp=') && request.body.include?('sig=')
+    end.to_return(response, error_response)
+
+    assert_kind_of Vonage::Response, sms_with_sig_auth.send(params)
+
+    error = assert_raises Vonage::ServiceError do
+      sms_with_sig_auth.send(params)
+    end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_mapping_underscored_keys_to_hyphenated_string_keys
     params = {'status-report-req' => '1', 'text' => 'Hey'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response)
 
     assert_kind_of Vonage::Response, sms.send(text: 'Hey', status_report_req: 1)
   end
@@ -76,7 +108,7 @@ class Vonage::SMSTest < Vonage::Test
 
     params = {from: 'Ruby', to: msisdn, text: "Unicode \u2713"}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response)
 
     sms.send(params)
 

--- a/test/vonage/subaccounts_test.rb
+++ b/test/vonage/subaccounts_test.rb
@@ -18,6 +18,10 @@ class Vonage::SubaccountsTest < Vonage::Test
     'vonage-subaccount-api-key'
   end
 
+  def authorization
+    basic_authorization
+  end
+
   def test_list_method
     stub_request(:get, subaccounts_uri).to_return(subaccounts_list_response)
 
@@ -42,13 +46,13 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_create_method
-    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo" }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.create(name: "Foo")
   end
 
   def test_create_method_with_optional_params
-    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, subaccounts_uri).with(request(body: { name: "Foo", secret: "Password123", use_primary_account_balance: false })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.create(name: "Foo", secret: "Password123", use_primary_account_balance: false)
   end
@@ -60,7 +64,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_update_method
-    stub_request(:patch, "#{subaccounts_uri}/#{subaccount_api_key}").with(request(body: { name: "Bar" }, auth: basic_authorization)).to_return(response)
+    stub_request(:patch, "#{subaccounts_uri}/#{subaccount_api_key}").with(request(body: { name: "Bar" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.update(subaccount_key: subaccount_api_key, name: "Bar")
   end
@@ -73,7 +77,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_credit_transfers_method
     query = "?start_date=2023-06-15T15:53:50Z"
-    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response)
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request).to_return(credit_transfers_list_response)
 
     credit_transfers_list = subaccounts.list_credit_transfers(start_date: "2023-06-15T15:53:50Z")
 
@@ -83,7 +87,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_credit_transfers_method_with_optional_params
     query = "?start_date=2023-06-15T15:53:50Z&subaccount=abc123"
-    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response_filtered)
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request).to_return(credit_transfers_list_response_filtered)
 
     credit_transfers_list = subaccounts.list_credit_transfers(start_date: "2023-06-15T15:53:50Z", subaccount: 'abc123')
 
@@ -93,7 +97,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_credit_transfers_method_without_start_date_uses_default
     query = "?start_date=1970-01-01T00:00:00Z"
-    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request(auth: basic_authorization)).to_return(credit_transfers_list_response)
+    stub_request(:get, "#{accounts_uri}/credit-transfers#{query}").with(request).to_return(credit_transfers_list_response)
 
     credit_transfers_list = subaccounts.list_credit_transfers
 
@@ -102,13 +106,13 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_credit_method
-    stub_request(:post, "#{accounts_uri}/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, "#{accounts_uri}/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_credit(from: "abc123", to: "def456", amount: "123.45")
   end
 
   def test_transfer_credit_method_with_optional_params
-    stub_request(:post, "#{accounts_uri}/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, "#{accounts_uri}/credit-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_credit(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
   end
@@ -133,7 +137,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_balance_transfers_method
     query = "?start_date=2023-06-15T15:53:50Z"
-    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response)
+    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request).to_return(balance_transfers_list_response)
 
     balance_transfers_list = subaccounts.list_balance_transfers(start_date: "2023-06-15T15:53:50Z")
 
@@ -143,7 +147,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_balance_transfers_method_with_optional_params
     query = "?start_date=2023-06-15T15:53:50Z&subaccount=abc123"
-    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response_filtered)
+    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request).to_return(balance_transfers_list_response_filtered)
 
     balance_transfers_list = subaccounts.list_balance_transfers(start_date: "2023-06-15T15:53:50Z", subaccount: 'abc123')
 
@@ -153,7 +157,7 @@ class Vonage::SubaccountsTest < Vonage::Test
 
   def test_list_balance_transfers_method_without_start_date_uses_default
     query = "?start_date=1970-01-01T00:00:00Z"
-    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request(auth: basic_authorization)).to_return(balance_transfers_list_response)
+    stub_request(:get, "#{accounts_uri}/balance-transfers#{query}").with(request).to_return(balance_transfers_list_response)
 
     balance_transfers_list = subaccounts.list_balance_transfers
 
@@ -162,13 +166,13 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_balance_method
-    stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45")
   end
 
   def test_transfer_balance_method_with_optional_params
-    stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, "#{accounts_uri}/balance-transfers").with(request(body: { from: "abc123", to: "def456", amount: "123.45", reference: "Foo" })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_balance(from: "abc123", to: "def456", amount: "123.45", reference: "Foo" )
   end
@@ -192,7 +196,7 @@ class Vonage::SubaccountsTest < Vonage::Test
   end
 
   def test_transfer_number_method
-    stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' }, auth: basic_authorization)).to_return(response)
+    stub_request(:post, "#{accounts_uri}/transfer-number").with(request(body: { from: "abc123", to: "def456", number: 23507703696, country: 'GB' })).to_return(response)
 
     assert_kind_of Vonage::Response, subaccounts.transfer_number(from: "abc123", to: "def456", number: 23507703696, country: 'GB')
   end

--- a/test/vonage/test.rb
+++ b/test/vonage/test.rb
@@ -112,8 +112,8 @@ module Vonage
       "api-eu.vonage.com"
     end
 
-    def request(body: nil, query: nil, headers: {}, auth: nil)
-      headers['Authorization'] = auth || authorization
+    def request(body: nil, query: nil, headers: {})
+      headers['Authorization'] = authorization
       if body
         headers['Content-Type'] = 'application/json' unless headers.has_key?('Content-Type')
       end

--- a/test/vonage/verify_test.rb
+++ b/test/vonage/verify_test.rb
@@ -6,6 +6,10 @@ class Vonage::VerifyTest < Vonage::Test
     Vonage::Verify.new(config)
   end
 
+  def authorization
+    basic_authorization
+  end
+
   def request_id
     '8g88g88eg8g8gg9g90'
   end
@@ -50,7 +54,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.request(params)
 
@@ -67,7 +71,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(error_response_blocklist_with_network)
 
     error = assert_raises Vonage::ServiceError do
       verify.request(params)
@@ -82,7 +86,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_request_id)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(error_response_blocklist_with_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.request(params)
@@ -97,7 +101,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, brand: 'ExampleApp'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network_and_request_id)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(error_response_blocklist_with_network_and_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.request(params)
@@ -112,7 +116,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {request_id: request_id, code: '123445'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.check(params)
 
@@ -129,7 +133,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {request_id: request_id}
 
-    stub_request(:get, uri).with(query: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:get, uri).with(request(query: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.search(params)
 
@@ -146,7 +150,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {request_id: request_id, cmd: 'cancel'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.control(params)
 
@@ -163,7 +167,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {request_id: request_id, cmd: 'cancel'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.cancel(request_id)
 
@@ -180,7 +184,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {request_id: request_id, cmd: 'trigger_next_event'}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.trigger_next_event(request_id)
 
@@ -197,7 +201,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(response, error_response)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(response, error_response)
 
     assert_kind_of Vonage::Response, verify.psd2(params)
 
@@ -214,7 +218,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(error_response_blocklist_with_network)
 
     error = assert_raises Vonage::ServiceError do
       verify.psd2(params)
@@ -229,7 +233,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_request_id)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(error_response_blocklist_with_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.psd2(params)
@@ -244,7 +248,7 @@ class Vonage::VerifyTest < Vonage::Test
 
     params = {number: msisdn, payee: 'ExampleApp', amount: 48.00}
 
-    stub_request(:post, uri).with(headers: headers, body: params.merge(api_key_and_secret)).to_return(error_response_blocklist_with_network_and_request_id)
+    stub_request(:post, uri).with(request(headers: headers, body: params)).to_return(error_response_blocklist_with_network_and_request_id)
 
     error = assert_raises Vonage::ServiceError do
       verify.psd2(params)


### PR DESCRIPTION
This PR updates a number of the older API implementations to use Basic Authentication by default. Specifically:

- SMS API
- Verify v1 API
- Number Insight v1 API
- Account API
- Conversion API

I also adds logic so that the API implementations that also support Signature Authentication can continue to do so (SMS API and Conversion API).

The PR also adds/updates unit tests to cover the above changes.