### PR TITLE
feat: Verify and Voice Updates Jan 2026

### DIFF
--- a/lib/vonage/verify2/channels/silent_auth.rb
+++ b/lib/vonage/verify2/channels/silent_auth.rb
@@ -27,7 +27,6 @@ module Vonage
 
     # @deprecated: This method is deprecated and will be removed in a future release.
     def sandbox=(sandbox)
-      logger.info('This method is deprecated and will be removed in a future release.')
       raise ArgumentError, "Invalid 'sandbox' value #{sandbox}. Expected to be boolean value" unless [true, false].include? sandbox
       @sandbox = sandbox
     end

--- a/lib/vonage/verify2/channels/silent_auth.rb
+++ b/lib/vonage/verify2/channels/silent_auth.rb
@@ -25,7 +25,9 @@ module Vonage
       @redirect_url = redirect_url
     end
 
+    # @deprecated: This method is deprecated and will be removed in a future release.
     def sandbox=(sandbox)
+      logger.info('This method is deprecated and will be removed in a future release.')
       raise ArgumentError, "Invalid 'sandbox' value #{sandbox}. Expected to be boolean value" unless [true, false].include? sandbox
       @sandbox = sandbox
     end

--- a/lib/vonage/voice/actions/connect.rb
+++ b/lib/vonage/voice/actions/connect.rb
@@ -185,6 +185,7 @@ module Vonage
 
       hash.merge!(dtmfAnswer: endpoint_attrs[:dtmfAnswer]) if endpoint_attrs[:dtmfAnswer]
       hash.merge!(onAnswer: endpoint_attrs[:onAnswer]) if endpoint_attrs[:onAnswer]
+      hash.merge!(shaken: endpoint_attrs[:shaken]) if endpoint_attrs[:shaken]
 
       hash
     end

--- a/lib/vonage/voice/actions/connect.rb
+++ b/lib/vonage/voice/actions/connect.rb
@@ -153,6 +153,7 @@ module Vonage
       ncco[0].merge!(timeout: builder.timeout) if builder.timeout
       ncco[0].merge!(limit: builder.limit) if builder.limit
       ncco[0].merge!(machineDetection: builder.machineDetection) if builder.machineDetection
+      ncco[0].merge!(advanced_machine_detection: builder.advanced_machine_detection) if builder.advanced_machine_detection
       ncco[0].merge!(eventUrl: builder.eventUrl) if builder.eventUrl
       ncco[0].merge!(eventMethod: builder.eventMethod) if builder.eventMethod
       ncco[0].merge!(ringbackTone: builder.ringbackTone) if builder.ringbackTone

--- a/test/vonage/voice/actions/connect_test.rb
+++ b/test/vonage/voice/actions/connect_test.rb
@@ -9,6 +9,17 @@ class Vonage::Voice::Actions::ConnectTest < Vonage::Test
     assert_equal connect.endpoint, { type: 'app', user: 'joe' }
   end
 
+  def test_connect_initialize_with_advanced_machine_detection
+    connect = Vonage::Voice::Actions::Connect.new(
+      endpoint: { type: 'phone', number: '12129999999' },
+      advanced_machine_detection: { behavior: 'continue', mode: 'detect_beep', beep_timeout: 60 }
+    )
+
+    assert_kind_of Vonage::Voice::Actions::Connect, connect
+    assert_equal connect.endpoint, { type: 'phone', number: '12129999999' }
+    assert_equal connect.advanced_machine_detection, { behavior: 'continue', mode: 'detect_beep', beep_timeout: 60 }
+  end
+
   def test_create_endpoint_with_phone
     expected = { type: 'phone', number: '12129999999' }
     connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'phone', number: '12129999999' })
@@ -186,6 +197,28 @@ class Vonage::Voice::Actions::ConnectTest < Vonage::Test
     exception = assert_raises { Vonage::Voice::Actions::Connect.new(endpoint: { type: 'phone', number: '12122222222' }, ringbackTone: 'invalid') }
 
     assert_match "Invalid 'ringbackTone' value, must be a valid URL", exception.message
+  end
+
+  def test_action_method_with_advanced_machine_detection
+    connect = Vonage::Voice::Actions::Connect.new(
+      endpoint: { type: 'phone', number: '12129999999' },
+      advanced_machine_detection: { behavior: 'continue', mode: 'detect_beep', beep_timeout: 60 }
+    )
+
+    expected = [{
+      action: 'connect',
+      endpoint: [{
+        type: 'phone',
+        number: '12129999999'
+      }],
+      advanced_machine_detection: {
+        behavior: 'continue',
+        mode: 'detect_beep',
+        beep_timeout: 60
+      }
+    }]
+
+    assert_equal expected, connect.action
   end
 
 end

--- a/test/vonage/voice/actions/connect_test.rb
+++ b/test/vonage/voice/actions/connect_test.rb
@@ -23,6 +23,13 @@ class Vonage::Voice::Actions::ConnectTest < Vonage::Test
     assert_equal expected, connect.create_endpoint(connect)
   end
 
+  def test_create_endpoint_with_phone_and_shaken_param
+    expected = { type: 'phone', number: '12129999999', shaken: "eyJhbGciOiJFUzI1NiIsInBwdCI6InNoYWtlbiIsInR5cCI6InBhc3Nwb3J0IiwieDV1IjoiaHR0cHM6Ly9jZXJ0LmV4YW1wbGUuY29tL3Bhc3Nwb3J0LnBlbSJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMjEyNTU1MTIxMiJdfSwiaWF0IjoxNjk0ODcwNDAwLCJvcmlnIjp7InRuIjoiMTQxNTU1NTEyMzQifSwib3JpZ2lkIjoiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAwIn0.MEUCIQCrfKeMtvn9I6zXjE2VfGEcdjC2sm5M6cPqBvFyV9XkpQIgLxlvLNmC8DJEKexXZqTZ;info=<https://stir-provider.example.net/cert.cer>;alg=ES256;ppt=shaken" }
+    connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'phone', number: '12129999999', shaken: "eyJhbGciOiJFUzI1NiIsInBwdCI6InNoYWtlbiIsInR5cCI6InBhc3Nwb3J0IiwieDV1IjoiaHR0cHM6Ly9jZXJ0LmV4YW1wbGUuY29tL3Bhc3Nwb3J0LnBlbSJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMjEyNTU1MTIxMiJdfSwiaWF0IjoxNjk0ODcwNDAwLCJvcmlnIjp7InRuIjoiMTQxNTU1NTEyMzQifSwib3JpZ2lkIjoiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAwIn0.MEUCIQCrfKeMtvn9I6zXjE2VfGEcdjC2sm5M6cPqBvFyV9XkpQIgLxlvLNmC8DJEKexXZqTZ;info=<https://stir-provider.example.net/cert.cer>;alg=ES256;ppt=shaken" })
+
+    assert_equal expected, connect.create_endpoint(connect)
+  end
+
   def test_create_endpoint_with_app
     expected = { type: 'app', user: 'joe' }
     connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'app', user: 'joe' })

--- a/test/vonage/voice_test.rb
+++ b/test/vonage/voice_test.rb
@@ -26,6 +26,24 @@ class Vonage::VoiceTest < Vonage::Test
     assert_kind_of Vonage::Response, calls.create(params)
   end
 
+  def test_create_method_with_connect_to_phone_with_shaken_property
+    params = {
+      to: [
+        {
+          type: 'phone',
+          number: '14843331234',
+          shaken: "eyJhbGciOiJFUzI1NiIsInBwdCI6InNoYWtlbiIsInR5cCI6InBhc3Nwb3J0IiwieDV1IjoiaHR0cHM6Ly9jZXJ0LmV4YW1wbGUuY29tL3Bhc3Nwb3J0LnBlbSJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMjEyNTU1MTIxMiJdfSwiaWF0IjoxNjk0ODcwNDAwLCJvcmlnIjp7InRuIjoiMTQxNTU1NTEyMzQifSwib3JpZ2lkIjoiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAwIn0.MEUCIQCrfKeMtvn9I6zXjE2VfGEcdjC2sm5M6cPqBvFyV9XkpQIgLxlvLNmC8DJEKexXZqTZ;info=<https://stir-provider.example.net/cert.cer>;alg=ES256;ppt=shaken"
+      }
+      ],
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+
+    stub_request(:post, calls_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, calls.create(params)
+  end
+
   def test_create_method_with_connect_to_sip_standard_headers
     params = {
       to: [


### PR DESCRIPTION
This PR makes some small updates to the implementations for the Voice and Verify products. Specifically it:

- Marks the `sandbox` setter in the Verify Silent Authentication options builder as deprecated
- Adds support for the `shaken` property in the Voice `Calls#create` method and the `connect` NCCO action
- Fixes a bug with the `advance_machine_detection` property of the `connect` NCCO action