### PR TITLE
feat: Add multi-auth support to Messages and Verify2

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,26 @@ Supported algorithms are:
 
 #### Products with Multiple Authentication Methods
 
+Some Vonage API products support more than one authentication method. For these products the Ruby SDK sets a default authentication method, but this default can be over-ridden in the `Client` configuration using the `authentication_preference` setting. For example, the Messages API supports both Basic Authentication and Bearer Token (JWT) Authentication. For its Messages API implementation the Ruby SDK defaults to Bearer Token (JWT) Authentication and so you would normally need to provide a Vonage Application ID and Private Key as credentials in order to authenticate when using the Messages API via the Ruby SDK. However, you can instead provide your Vonage API Key and API Secret and set the `Client` object to use Basic Authentication instead:
+
+```
+# .env
+VONAGE_API_KEY=abc123
+VONAGE_API_SECRET=abc123456789
+```
+
+```ruby
+client = Vonage::Client.new(authentication_preference: :basic)
+```
+
+Below is a list of Vonage API products currently implemented in the Ruby SDK that support more than one authentication method.
+
+| Product | Authentication Methods | Default | Over-ride Key |
+|---|---|---|---|
+| Messages API | JWT, Basic | JWT | `:basic` |
+| Verify API v2 | JWT, Basic | JWT | `:basic` |
+| SMS API | Basic, Signature | Basic | `:signature` |
+
 ### Logging
 
 Use the logger option to specify a logger. For example:

--- a/README.md
+++ b/README.md
@@ -239,7 +239,67 @@ Documentation for the Vonage Ruby JWT generator gem can be found at: https://www
 
 The documentation outlines all the possible parameters you can use to customize and build a token with.
 
-### Products with Multiple Authentication Methods
+#### Signature Authentication
+
+Signature authentication signs the request using a signature created via a signing algorithm and using your Vonage Signature Secret. You can read more about this authentication method in the [Vonage documentation](https://developer.vonage.com/en/getting-started/concepts/signing-messages).
+
+To create the signature the SDK requires access to your API Key and Signature Secret. You can either:
+
+1. Pass them in to the `Client` constructor as `api_key` and `signature_secret` keyword arguments, either passing in the values directly or as environement variables with custom keys:
+    ```ruby
+    client = Vonage::Client.new(api_key: 'abc123', signature_secret: 'hdEooIhQYgo5XAcmbfLfpy5ROcEwGbjcwj6EvywwvYNOxKWj71')
+    ```
+    or
+    ```
+    # .env
+    MY_API_KEY=abc123
+    MY_SIGNATURE_SECRET=hdEooIhQYgo5XAcmbfLfpy5ROcEwGbjcwj6EvywwvYNOxKWj71
+    ```
+    ```ruby
+    client = Vonage::Client.new(api_key: ENV['MY_API_KEY'], api_secret: ENV['MY_SIGNATURE_SECRET'])
+    ```
+
+2. Set them as environment variables with the `VONAGE_API_KEY` and `VONAGE_SIGNATURE_SECRET` keys and then call the constructor without the keyword arguments:
+    ```
+    # .env
+    VONAGE_API_KEY=abc123
+    VONAGE_SIGNATURE_SECRET=hdEooIhQYgo5XAcmbfLfpy5ROcEwGbjcwj6EvywwvYNOxKWj71
+    ```
+    ```ruby
+    client = Vonage::Client.new
+    ```
+
+By default, the Ruby SDK uses the MD5 HASH algorithm to generate the signature. If you've set a different algorithm in your [Vonage API Settings](https://dashboard.vonage.com/settings), you'll need to over-ride the default when instantiating the `Client` object, for example:
+
+```ruby
+  client = Vonage::Client.new(
+    api_key: 'abc123',
+    signature_secret: 'hdEooIhQYgo5XAcmbfLfpy5ROcEwGbjcwj6EvywwvYNOxKWj71',
+    signature_method: 'sha512'
+  )
+```
+
+You can also set the Signature Method as the `VONAGE_SIGNATURE_METHOD` environment variable, for example:
+
+```
+# .env
+VONAGE_API_KEY=abc123
+VONAGE_SIGNATURE_SECRET=hdEooIhQYgo5XAcmbfLfpy5ROcEwGbjcwj6EvywwvYNOxKWj71
+VONAGE_SIGNATURE_METHOD=sha512
+```
+```ruby
+client = Vonage::Client.new
+```
+
+Supported algorithms are:
+
+- `md5hash`
+- `md5` (HMAC)
+- `sha1`
+- `sha256`
+- `sha512`
+
+#### Products with Multiple Authentication Methods
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ need a Vonage account. Sign up [for free at vonage.com][signup].
 * [Requirements](#requirements)
 * [Installation](#installation)
 * [Usage](#usage)
+    * [Authentication](#authentication)
+      * [Basic Authentication](#basic-authentication)
+      * [JWT Authentication](#jwt-authentication)
+      * [Signature Authentication](#signature-authentication)
     * [Logging](#logging)
     * [Exceptions](#exceptions)
     * [Overriding the default hosts](#overriding-the-default-hosts)
@@ -69,7 +73,7 @@ When instantiating the `Client` object you can pass in various arguments to conf
 
 ### Authentication
 
-All requests to the Vonage APIs are authenticated, so the `Client` object will need access to your Vonage credentials. Different Vonage API products support different authenitcations methods, so the credentials required will depend on the authenticatons method used. A few API products also support [multiple authentication methods](#products-with-multiple-authentication-methods).
+All requests to the Vonage APIs are authenticated, so the `Client` object will need access to your Vonage credentials. Different Vonage API products support different authenitcations methods, so the credentials required will depend on the authenticaton method used. A few API products also support [multiple authentication methods](#products-with-multiple-authentication-methods).
 
 Currently, all Vonage API products support one or more of the following authentication methods:
 
@@ -79,7 +83,7 @@ Currently, all Vonage API products support one or more of the following authenti
 
 For a complete list of which products support which authentication methods, please refer to the [Vonage documentation on this topic](https://developer.vonage.com/en/getting-started/concepts/authentication).
 
-Providing the necessary credentials to the client can be done in a number of ways. You could pass the credentials as keyword arguments when calling `Client.new`, for example in order to provide you API Key and API Secret you could use the `api_key` and `api_secret` keyword arguments respectively. You could pass the value for these arguments directly in the method call like so:
+Providing the necessary credentials to the client can be done in a number of ways. You can pass the credentials as keyword arguments when calling `Client.new`, for example in order to provide you API Key and API Secret you could use the `api_key` and `api_secret` keyword arguments respectively. You can pass the value for these arguments directly in the method call like so:
 
 ```ruby
 client = Vonage::Client.new(api_key: 'abc123', api_secret: 'abc123456789')
@@ -205,7 +209,7 @@ For example, if you had your private key stored in a file called `private.key` i
     client = Vonage::Client.new
     ```
 
-    If `VONAGE_PRIVATE_KEY_PATH` is set, then the Ruby SDK will attempt to read in the contents of the file at the path provided and use thsoe contents as the Private Key.
+    If `VONAGE_PRIVATE_KEY_PATH` is set, then the Ruby SDK will attempt to read in the contents of the file at the path provided and use those contents as the Private Key.
 
 > [!TIP]
 > You can download your Private Key file when creating or updating a Vonage Application in the [Vonage Developer Dashboard](https://dashboard.vonage.com/applications), or creating a Vonage Application with the [Vonage CLI](https://github.com/vonage/vonage-cli). You can also create your own file using the value of the `keys.private_key` param provided in the HTTP response when creating a Vonage Application using the [Application API](https://developer.vonage.com/en/application/overview).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ require 'vonage'
 Then construct a client object with your key and secret:
 
 ```ruby
-client = Vonage::Client.new(api_key: 'YOUR-API-KEY', api_secret: 'YOUR-API-SECRET')
+client = Vonage::Client.new
 ```
 
 You can now use the client object to call Vonage APIs. For example, to send an SMS:
@@ -65,16 +65,45 @@ You can now use the client object to call Vonage APIs. For example, to send an S
 client.sms.send(from: 'Ruby', to: '447700900000', text: 'Hello world')
 ```
 
-For production you can specify the `VONAGE_API_KEY` and `VONAGE_API_SECRET`
-environment variables instead of specifying the key and secret explicitly,
-keeping your credentials out of source control.
+When instantiating the `Client` object you can pass in various arguments to configure it such as credentials for [authentication](#authentication), values for [overriding the default hosts](overriding-the-default-hosts), or [configuration options for the HTTP client](#http-client-configuration).
 
-For APIs which use a JWT for authentication you'll need to pass `application_id` and `private_key` arguments to the
-`Client` constructor as well as or instead of `api_key` and `api_secret`. See [JWT Authentication](#jwt-authentication).
+### Authentication
 
-It is also possible to over-ride the default hosts at `Client` instantiation. See [Overriding the default hosts](overriding-the-default-hosts).
+All requests to the Vonage APIs are authenticated, so the `Client` object will need access to your Vonage credentials. Different Vonage API products support different authenitcations methods, so the credentials required will depend on the authenticatons method used.
 
-### JWT authentication
+Currently, all Vonage API products support one or more of the following authentication methods:
+
+- [Basic Authentication](#basic-authentication)
+- [JWT Authentication](#jwt-authentication)
+- [Signature Authentication](#signature-authentication)
+
+For a complete list of which products support which authentication methods, please refer to the [Vonage documentation on this topic](https://developer.vonage.com/en/getting-started/concepts/authentication).
+
+Providing the necessary credentials to the client can be done in a number of ways. You could pass the credentials as keyword arguments when calling `Client.new`, for example in order to provide you API Key and API Secret you could use the `api_key` and `api_secret` keyword arguments respectively. You could pass the value for these arguments directly in the method call like so:
+
+```ruby
+client = Vonage::Client.new(api_key: 'abc123', api_secret: 'abc123456789')
+```
+
+Generally though, and especially for production code or any code that you plan to push up to source control, you will want to avoid exposing your credentials directly in this way and instead use environment variables to define your credentials.
+
+> Note: when setting environment variables locally, such as in an `.env` file, you should include the name of that file in a `.gitignore` file if you are intending to push your code up to source control.
+
+You can choose to define your own custom environment variables and then use Ruby's `ENV` hash to pass them in as the values for your keyword arguments, for example:
+
+```ruby
+client = Vonage::Client.new(api_key: ENV['MY_API_KEY'], api_secret: ENV['MY_API_SECRET'])
+```
+
+A less verbose approach is to instantiate the client without passing in keyword arguments for the authentication credentials. In this case the `Config` object used by the `Client` will search your environment for some pre-defined environment variables and use the values of those variables if defined. The names of these pre-defined environment variables are outlined in the sections below on the specific authentication methods.
+
+Note that some Vonage API products support multiple authentication methods. In these cases the Ruby SDK sets a default authentication method for that product, which can be over-ridden with a configuration setting. You can learn more about this in the section on [Products with Multiple Authentication Methods](#products-with-multiple-authentication-methods).
+
+#### Basic Authentication
+
+
+
+#### JWT authentication
 
 To call newer endpoints that support JWT authentication such as the Voice API and Messages API you'll
 also need to specify the `application_id` and `private_key` options. For example:
@@ -108,6 +137,8 @@ client = Vonage::Client.new(token: token)
 Documentation for the Vonage Ruby JWT generator gem can be found at: https://www.rubydoc.info/gems/vonage-jwt
 
 The documentation outlines all the possible parameters you can use to customize and build a token with.
+
+### Products with Multiple Authentication Methods
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When instantiating the `Client` object you can pass in various arguments to conf
 
 ### Authentication
 
-All requests to the Vonage APIs are authenticated, so the `Client` object will need access to your Vonage credentials. Different Vonage API products support different authenitcations methods, so the credentials required will depend on the authenticatons method used.
+All requests to the Vonage APIs are authenticated, so the `Client` object will need access to your Vonage credentials. Different Vonage API products support different authenitcations methods, so the credentials required will depend on the authenticatons method used. A few API products also support [multiple authentication methods](#products-with-multiple-authentication-methods).
 
 Currently, all Vonage API products support one or more of the following authentication methods:
 
@@ -87,7 +87,8 @@ client = Vonage::Client.new(api_key: 'abc123', api_secret: 'abc123456789')
 
 Generally though, and especially for production code or any code that you plan to push up to source control, you will want to avoid exposing your credentials directly in this way and instead use environment variables to define your credentials.
 
-> Note: when setting environment variables locally, such as in an `.env` file, you should include the name of that file in a `.gitignore` file if you are intending to push your code up to source control.
+> [!CAUTION]
+> When setting environment variables locally, if using a file to do this (such as in an `.env` file), you should include the name of that file in a `.gitignore` file if you are intending to push your code up to source control.
 
 You can choose to define your own custom environment variables and then use Ruby's `ENV` hash to pass them in as the values for your keyword arguments, for example:
 
@@ -95,44 +96,144 @@ You can choose to define your own custom environment variables and then use Ruby
 client = Vonage::Client.new(api_key: ENV['MY_API_KEY'], api_secret: ENV['MY_API_SECRET'])
 ```
 
-A less verbose approach is to instantiate the client without passing in keyword arguments for the authentication credentials. In this case the `Config` object used by the `Client` will search your environment for some pre-defined environment variables and use the values of those variables if defined. The names of these pre-defined environment variables are outlined in the sections below on the specific authentication methods.
+A less verbose approach is to instantiate the client *without* passing in keyword arguments for the authentication credentials. 
+
+```ruby
+client = Vonage::Client.new
+```
+
+In this case the `Config` object used by the `Client` will search your environment for some pre-defined environment variables and use the values of those variables if defined. The names of these pre-defined environment variables are outlined in the sections below on the specific authentication methods.
 
 Note that some Vonage API products support multiple authentication methods. In these cases the Ruby SDK sets a default authentication method for that product, which can be over-ridden with a configuration setting. You can learn more about this in the section on [Products with Multiple Authentication Methods](#products-with-multiple-authentication-methods).
 
 #### Basic Authentication
 
+For products that use Basic Authentication, the Ruby SDK sets an `Authorization` header on the HTTP request with a value containing a Base64 encoded version of your API key and secret. You can read more about this authentication method in the [Vonage documentation](https://developer.vonage.com/en/getting-started/concepts/authentication?source=getting-started#basic-authentication).
 
+To set the header the SDK requires access to your API Key and API Secret. You can either:
 
-#### JWT authentication
+1. Pass them in to the `Client` constructor as `api_key` and `api_secret` keyword arguments, either passing in the values directly or as environement variables with custom keys:
+    ```ruby
+    client = Vonage::Client.new(api_key: 'abc123', api_secret: 'abc123456789')
+    ```
+    or
+    ```
+    # .env
+    MY_API_KEY=abc123
+    MY_API_SECRET=abc123456789
+    ```
+    ```ruby
+    client = Vonage::Client.new(api_key: ENV['MY_API_KEY'], api_secret: ENV['MY_API_SECRET'])
+    ```
 
-To call newer endpoints that support JWT authentication such as the Voice API and Messages API you'll
-also need to specify the `application_id` and `private_key` options. For example:
+2. Set them as environment variables with the `VONAGE_API_KEY` and `VONAGE_API_SECRET` keys and then call the constructor without the keyword arguments:
+    ```
+    # .env
+    VONAGE_API_KEY=abc123
+    VONAGE_API_SECRET=abc123456789
+    ```
+    ```ruby
+    client = Vonage::Client.new
+    ```
 
-```ruby
-client = Vonage::Client.new(application_id: application_id, private_key: private_key)
-```
+#### JWT Authentication
 
-Both arguments should have string values corresponding to the `id` and `private_key`
-values returned in a ["create an application"](https://developer.vonage.com/api/application.v2#createApplication)
-response. These credentials can be stored in a datastore, in environment variables,
-on disk outside of source control, or in some kind of key management infrastructure.
+For products that use Bearer (JWT) Authentication, the Ruby SDK sets an `Authorization` header on the HTTP request with a value containing a JSON Web Token (JWT) derived from an Application ID and Private Key. You can read more about this authentication method in the [Vonage documentation](https://developer.vonage.com/en/getting-started/concepts/authentication#json-web-tokens), but in brief you will need to create a Vonage Application (for example via the [Vonage Developer Dashboard](https://dashboard.vonage.com/applications), [Application API](https://developer.vonage.com/en/application/overview), or [Vonage CLI](https://github.com/vonage/vonage-cli)). This Application will be assigned a unique ID upon creation. You can then generate a public and private key pair specific to this Application.
 
-By default the library generates a short lived JWT per request. To generate a long lived
-JWT for multiple requests or to specify JWT claims directly use `Vonage::JWT.generate` and
-the token option. For example:
+The Ruby SDK automatically generates the JWT and sets the `Authorization` header for you. To do this it requires access to an Application ID and assocaited Private Key. You can either:
+
+1. Pass them in to the `Client` constructor as `application_id` and `private_key` keyword arguments, either passing in the values directly or as environement variables with custom keys:
+    ```ruby
+    client = Vonage::Client.new(
+      application_id: '78d335fa-323d-0114-9c3d-d6f0d48968cf',
+      private_key: '-----BEGIN PRIVATE KEY----- MIIEvQIBADANBgkqhkiG9w0BAQEFA........'
+    )
+    ```
+    or
+    ```
+    # .env
+    MY_APPLICATION_ID=78d335fa-323d-0114-9c3d-d6f0d48968cf
+    MY_PRIVATE_KEY=-----BEGIN PRIVATE KEY----- MIIEvQIBADANBgkqhkiG9w0BAQEFA........
+    ```
+    ```ruby
+    client = Vonage::Client.new(application_id: ENV['MY_APPLICATION_ID'], private_key: ENV['MY_PRIVATE_KEY'])
+    ```
+  
+2. Set them as environment variables with the `VONAGE_APPLICATION_ID` and `VONAGE_PRIVATE_KEY` keys and then call the constructor without the keyword arguments:
+    ```
+    # .env
+    VONAGE_APPLICATION_ID=78d335fa-323d-0114-9c3d-d6f0d48968cf
+    VONAGE_PRIVATE_KEY=-----BEGIN PRIVATE KEY----- MIIEvQIBADANBgkqhkiG9w0BAQEFA........
+    ```
+    ```ruby
+    client = Vonage::Client.new
+    ```
+
+##### Using a Private Key File
+
+Using the private key directly, whether to pass it in as a keyword argument or set it as an environment variable, can be a litle bit unweildy. Another option is to store it in a `.key` file and then read the contents of that file in as necessary.
+
+> [!CAUTION]
+> You should include the name of your Private Key file in a `.gitignore` file if you are intending to push your code up to source control.
+
+For example, if you had your private key stored in a file called `private.key` in the root directory of your Ruby application, you could:
+
+1. Read the contents of the file in using Ruby's `File.read` method when passing the `private_key` keyword argument to the `Client` constructor, either by passing the filepath directly or as an environement variables with a custom key:
+    ```ruby
+    client = Vonage::Client.new(
+      application_id: '78d335fa-323d-0114-9c3d-d6f0d48968cf',
+      private_key: File.read('/private.key)
+    )
+    ```
+    or
+    ```
+    # .env
+    MY_APPLICATION_ID=78d335fa-323d-0114-9c3d-d6f0d48968cf
+    MY_PRIVATE_KEY_PATH=/private.key
+    ```
+    ```ruby
+    client = Vonage::Client.new(application_id: ENV['MY_APPLICATION_ID'], private_key: File.read(ENV['MY_PRIVATE_KEY_PATH']))
+    ```
+
+2. Set the path as an environment variable with the `VONAGE_PRIVATE_KEY_PATH` key (note: this is used in place of the `VONAGE_PRIVATE_KEY` key) and then call the constructor without the keyword arguments:
+    ```
+    # .env
+    VONAGE_APPLICATION_ID=78d335fa-323d-0114-9c3d-d6f0d48968cf
+    VONAGE_PRIVATE_KEY_PATH=/private.key
+    ```
+    ```ruby
+    client = Vonage::Client.new
+    ```
+
+    If `VONAGE_PRIVATE_KEY_PATH` is set, then the Ruby SDK will attempt to read in the contents of the file at the path provided and use thsoe contents as the Private Key.
+
+> [!TIP]
+> You can download your Private Key file when creating or updating a Vonage Application in the [Vonage Developer Dashboard](https://dashboard.vonage.com/applications), or creating a Vonage Application with the [Vonage CLI](https://github.com/vonage/vonage-cli). You can also create your own file using the value of the `keys.private_key` param provided in the HTTP response when creating a Vonage Application using the [Application API](https://developer.vonage.com/en/application/overview).
+
+##### Custom JWTs
+
+By default the library generates a short lived JWT per request (the default `ttl` is `900` seconds). If you need to generate a long lived JWT for multiple requests or specify JWT claims directly use `Vonage::JWT.generate` to generate a custom JWT and then pass that in to the `Client` constructor using the `token` option. For example:
 
 ```ruby
 claims = {
-  application_id: application_id,
-  private_key: 'path/to/private.key',
+  application_id: ENV['VONAGE_APPLICATION_ID'],
+  private_key: File.read(ENV['VONAGE_PRIVATE_KEY_PATH']),
   nbf: 1483315200,
-  ttl: 800
+  ttl: 3600
 }
 
 token = Vonage::JWT.generate(claims)
 
 client = Vonage::Client.new(token: token)
 ```
+
+The `Client` object will then use the JWT that you passed in for any API requests rather than generating one on-the-fly for each request.
+
+> [!NOTE]  
+> 1. Unlike with the `Client` constructor, you **must** set `application_id` and `private_key` as key-value pairs in the `claims` Hash when generating a custom JWT.
+> 2. You can choose to set *either* `ttl` *or* `exp` in the `claims`:
+>     - If you set *both* `ttl` is ignored and `exp` is used
+>     - If you choose to set `exp` this must be set as the number of seconds since the UNIX epoch (if using `ttl` the generator calculates this for you)
 
 Documentation for the Vonage Ruby JWT generator gem can be found at: https://www.rubydoc.info/gems/vonage-jwt
 

--- a/lib/vonage/basic_and_bearer_token.rb
+++ b/lib/vonage/basic_and_bearer_token.rb
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+module Vonage
+  class BasicAndBearerToken < AbstractAuthentication
+    def update(object, data)
+      return unless object.is_a?(Net::HTTPRequest)
+
+      if @config.authentication_preference == :basic
+        object.basic_auth(@config.api_key, @config.api_secret)
+      else
+        object['Authorization'] = 'Bearer ' + @config.token
+      end
+    end
+  end
+
+  private_constant :BasicAndBearerToken
+end

--- a/lib/vonage/basic_and_signature.rb
+++ b/lib/vonage/basic_and_signature.rb
@@ -18,5 +18,5 @@ module Vonage
     end
   end
 
-  private_constant :Basic
+  private_constant :BasicAndSignature
 end

--- a/lib/vonage/messaging.rb
+++ b/lib/vonage/messaging.rb
@@ -6,7 +6,7 @@ module Vonage
   class Messaging < Namespace
     extend Forwardable
 
-    self.authentication = BearerToken
+    self.authentication = BasicAndBearerToken
 
     self.request_body = JSON
 

--- a/lib/vonage/verify2.rb
+++ b/lib/vonage/verify2.rb
@@ -3,7 +3,7 @@
 
 module Vonage
   class Verify2 < Namespace
-    self.authentication = BearerToken
+    self.authentication = BasicAndBearerToken
 
     self.request_body = JSON
 

--- a/lib/vonage/verify2/template_fragments.rb
+++ b/lib/vonage/verify2/template_fragments.rb
@@ -5,7 +5,7 @@ module Vonage
   class Verify2::TemplateFragments < Namespace
     CHANNELS = ['sms', 'voice'].freeze
 
-    self.authentication = BearerToken
+    self.authentication = BasicAndBearerToken
 
     self.request_body = JSON
 

--- a/lib/vonage/verify2/templates.rb
+++ b/lib/vonage/verify2/templates.rb
@@ -3,7 +3,7 @@
 
 module Vonage
   class Verify2::Templates < Namespace
-    self.authentication = BearerToken
+    self.authentication = BasicAndBearerToken
 
     self.request_body = JSON
 

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -6,6 +6,17 @@ class Vonage::MessagingTest < Vonage::Test
     Vonage::Messaging.new(config)
   end
 
+  def messaging_with_basic_auth
+    config = Vonage::Config.new.merge(
+      {
+        api_key: api_key,
+        api_secret: api_secret,
+        authentication_preference: :basic
+      }
+    )
+    Vonage::Messaging.new(config)
+  end
+
   def geo_specific_messaging_host
     'api-eu.vonage.com'
   end
@@ -78,6 +89,22 @@ class Vonage::MessagingTest < Vonage::Test
     message = messaging.sms(message: "Hello world!", opts: opts)
 
     assert_kind_of Vonage::Response, messaging.send(to: "447700900000", from: "447700900001", **message)
+  end
+
+  def test_send_method_with_basic_authentication
+    params = {
+      to: "447700900000",
+      from: "447700900001",
+      channel: "sms",
+      message_type: "text",
+      text: "Hello world!"
+    }
+
+    stub_request(:post, messaging_uri).with(request(body: params, auth_method: basic_authorization)).to_return(response)
+
+    message = messaging_with_basic_auth.sms(message: "Hello world!")
+
+    assert_kind_of Vonage::Response, messaging_with_basic_auth.send(to: "447700900000", from: "447700900001", **message)
   end
 
   def test_send_method_without_to

--- a/test/vonage/test.rb
+++ b/test/vonage/test.rb
@@ -112,8 +112,8 @@ module Vonage
       "api-eu.vonage.com"
     end
 
-    def request(body: nil, query: nil, headers: {})
-      headers['Authorization'] = authorization
+    def request(body: nil, query: nil, headers: {}, auth_method: nil)
+      headers['Authorization'] = auth_method || authorization
       if body
         headers['Content-Type'] = 'application/json' unless headers.has_key?('Content-Type')
       end

--- a/test/vonage/verify2/template_fragments_test.rb
+++ b/test/vonage/verify2/template_fragments_test.rb
@@ -5,6 +5,17 @@ class Vonage::Verify2::TemplateFragmentsTest < Vonage::Test
     Vonage::Verify2::TemplateFragments.new(config)
   end
 
+  def template_fragments_with_basic_auth
+    config = Vonage::Config.new.merge(
+      {
+        api_key: api_key,
+        api_secret: api_secret,
+        authentication_preference: :basic
+      }
+    )
+    Vonage::Verify2::TemplateFragments.new(config)
+  end
+
   def template_id
     '8f35a1a7-eb2f-4552-8fdf-fffdaee41bc9'
   end
@@ -43,6 +54,15 @@ class Vonage::Verify2::TemplateFragmentsTest < Vonage::Test
     template_fragments_list.each { |template_fragment| assert_kind_of Vonage::Entity, template_fragment }
   end
 
+  def test_list_method_with_basic_authentication
+    stub_request(:get, template_fragments_uri).with(request(auth_method: basic_authorization)).to_return(template_fragments_list_response)
+
+    template_fragments_list = template_fragments_with_basic_auth.list(template_id: template_id)
+
+    assert_kind_of Vonage::Verify2::TemplateFragments::ListResponse, template_fragments_list
+    template_fragments_list.each { |template_fragment| assert_kind_of Vonage::Entity, template_fragment }
+  end
+
   def test_list_method_without_template_id
     assert_raises(ArgumentError) { template_fragments.list }
   end
@@ -51,6 +71,12 @@ class Vonage::Verify2::TemplateFragmentsTest < Vonage::Test
     stub_request(:get, template_fragment_uri).to_return(response)
 
     assert_kind_of Vonage::Response, template_fragments.info(template_id: template_id, template_fragment_id: template_fragment_id)
+  end
+
+  def test_info_method_with_basic_authentication
+    stub_request(:get, template_fragment_uri).with(request(auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, template_fragments_with_basic_auth.info(template_id: template_id, template_fragment_id: template_fragment_id)
   end
 
   def test_info_method_without_template_id
@@ -65,6 +91,12 @@ class Vonage::Verify2::TemplateFragmentsTest < Vonage::Test
     stub_request(:post, template_fragments_uri).with(body: { channel: 'sms', locale: 'en-gb', text: 'Code: ${code}' }).to_return(response)
 
     assert_kind_of Vonage::Response, template_fragments.create(template_id: template_id, channel: 'sms', locale: 'en-gb', text: 'Code: ${code}')
+  end
+
+  def test_create_method_with_basic_authentication
+    stub_request(:post, template_fragments_uri).with(request(body: { channel: 'sms', locale: 'en-gb', text: 'Code: ${code}' }, auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, template_fragments_with_basic_auth.create(template_id: template_id, channel: 'sms', locale: 'en-gb', text: 'Code: ${code}')
   end
 
   def test_create_method_without_template_id
@@ -93,6 +125,12 @@ class Vonage::Verify2::TemplateFragmentsTest < Vonage::Test
     assert_kind_of Vonage::Response, template_fragments.update(template_id: template_id, template_fragment_id: template_fragment_id, text: 'Your code is: ${code}')
   end
 
+  def test_update_method_with_basic_authentication
+    stub_request(:patch, template_fragment_uri).with(request(body: { text: 'Your code is: ${code}' }, auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, template_fragments_with_basic_auth.update(template_id: template_id, template_fragment_id: template_fragment_id, text: 'Your code is: ${code}')
+  end
+
   def test_update_method_without_template_id
     assert_raises(ArgumentError) { template_fragments.update(template_fragment_id: template_fragment_id, text: 'Your code is: ${code}') }
   end
@@ -109,6 +147,12 @@ class Vonage::Verify2::TemplateFragmentsTest < Vonage::Test
     stub_request(:delete, template_fragment_uri).to_return(response)
 
     assert_kind_of Vonage::Response, template_fragments.delete(template_id: template_id, template_fragment_id: template_fragment_id)
+  end
+
+  def test_delete_method_with_basic_authentication
+    stub_request(:delete, template_fragment_uri).with(request(auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, template_fragments_with_basic_auth.delete(template_id: template_id, template_fragment_id: template_fragment_id)
   end
 
   def test_delete_method_without_template_id

--- a/test/vonage/verify2/templates_test.rb
+++ b/test/vonage/verify2/templates_test.rb
@@ -5,6 +5,17 @@ class Vonage::Verify2::TemplatesTest < Vonage::Test
     Vonage::Verify2::Templates.new(config)
   end
 
+  def templates_with_basic_auth
+    config = Vonage::Config.new.merge(
+      {
+        api_key: api_key,
+        api_secret: api_secret,
+        authentication_preference: :basic
+      }
+    )
+    Vonage::Verify2::Templates.new(config)
+  end
+
   def template_id
     '8f35a1a7-eb2f-4552-8fdf-fffdaee41bc9'
   end
@@ -39,10 +50,25 @@ class Vonage::Verify2::TemplatesTest < Vonage::Test
     templates_list.each { |template| assert_kind_of Vonage::Entity, template }
   end
 
+  def test_list_method_with_basic_authentication
+    stub_request(:get, templates_uri).with(request(auth_method: basic_authorization)).to_return(templates_list_response)
+
+    templates_list = templates_with_basic_auth.list
+
+    assert_kind_of Vonage::Verify2::Templates::ListResponse, templates_list
+    templates_list.each { |template| assert_kind_of Vonage::Entity, template }
+  end
+
   def test_info_method
     stub_request(:get, template_uri).to_return(response)
 
     assert_kind_of Vonage::Response, templates.info(template_id: template_id)
+  end
+
+  def test_info_method_with_basic_authentication
+    stub_request(:get, template_uri).with(request(auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, templates_with_basic_auth.info(template_id: template_id)
   end
 
   def test_info_method_without_template_id
@@ -55,6 +81,12 @@ class Vonage::Verify2::TemplatesTest < Vonage::Test
     assert_kind_of Vonage::Response, templates.create(name: 'My Template')
   end
 
+  def test_create_method_with_basic_authentication
+    stub_request(:post, templates_uri).with(request(body: { name: 'My Template' }, auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, templates_with_basic_auth.create(name: 'My Template')
+  end
+
   def test_create_method_without_name
     assert_raises(ArgumentError) { templates.create }
   end
@@ -65,6 +97,12 @@ class Vonage::Verify2::TemplatesTest < Vonage::Test
     assert_kind_of Vonage::Response, templates.update(template_id: template_id, name: 'My Updated Template', is_default: false)
   end
 
+  def test_update_method_with_basic_authentication
+    stub_request(:patch, template_uri).with(request(body: { name: 'My Updated Template', is_default: false }, auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, templates_with_basic_auth.update(template_id: template_id, name: 'My Updated Template', is_default: false)
+  end
+
   def test_update_method_without_template_id
     assert_raises(ArgumentError) { templates.update(name: 'My Updated Template', is_default: false) }
   end
@@ -73,6 +111,18 @@ class Vonage::Verify2::TemplatesTest < Vonage::Test
     stub_request(:delete, template_uri).to_return(response)
 
     assert_kind_of Vonage::Response, templates.delete(template_id: template_id)
+  end
+
+  def test_delete_method
+    stub_request(:delete, template_uri).to_return(response)
+
+    assert_kind_of Vonage::Response, templates.delete(template_id: template_id)
+  end
+
+  def test_delete_method_with_basic_authentication
+    stub_request(:delete, template_uri).with(request(auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, templates_with_basic_auth.delete(template_id: template_id)
   end
 
   def test_delete_method_without_template_id

--- a/test/vonage/verify2_test.rb
+++ b/test/vonage/verify2_test.rb
@@ -6,6 +6,17 @@ class Vonage::Verify2Test < Vonage::Test
     Vonage::Verify2.new(config)
   end
 
+  def verify2_with_basic_auth
+    config = Vonage::Config.new.merge(
+      {
+        api_key: api_key,
+        api_secret: api_secret,
+        authentication_preference: :basic
+      }
+    )
+    Vonage::Verify2.new(config)
+  end
+
   def request_id
     'c11236f4-00bf-4b89-84ba-88b25df97315'
   end
@@ -67,6 +78,14 @@ class Vonage::Verify2Test < Vonage::Test
     stub_request(:post, uri).with(body: params).to_return(response)
 
     assert_kind_of Vonage::Response, verify2.start_verification(brand: brand, workflow: workflow, **opts)
+  end
+
+  def test_start_verification_method_with_basic_authentication
+    workflow = [{channel: 'sms', to: to_number}]
+
+    stub_request(:post, uri).with(request(body: {brand: brand, workflow: workflow}, auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, verify2_with_basic_auth.start_verification(brand: brand, workflow: workflow)
   end
 
   def test_start_verification_method_without_brand
@@ -147,6 +166,14 @@ class Vonage::Verify2Test < Vonage::Test
     assert_kind_of Vonage::Response, verify2.check_code(request_id: request_id, code: code)
   end
 
+  def test_check_code_method_with_basic_authentication
+    code = '1234'
+
+    stub_request(:post, check_request_uri).with(request(body: {code: code}, auth_method: basic_authorization)).to_return(status: 200, headers: {})
+
+    assert_kind_of Vonage::Response, verify2_with_basic_auth.check_code(request_id: request_id, code: code)
+  end
+
   def test_check_code_method_without_request_id
     assert_raises ArgumentError do
       verify2.check_code(code: '1234')
@@ -163,6 +190,12 @@ class Vonage::Verify2Test < Vonage::Test
     stub_request(:post, uri + request_id + '/next_workflow').to_return(response)
 
     assert_kind_of Vonage::Response, verify2.next_workflow(request_id: request_id)
+  end
+
+  def test_next_workflow_method_with_basic_authentication
+    stub_request(:post, uri + request_id + '/next_workflow').with(request(auth_method: basic_authorization)).to_return(response)
+
+    assert_kind_of Vonage::Response, verify2_with_basic_auth.next_workflow(request_id: request_id)
   end
 
   def test_next_workflow_method_without_request_id
@@ -200,6 +233,12 @@ class Vonage::Verify2Test < Vonage::Test
     stub_request(:delete, cancel_request_uri).to_return(status: 204, headers: {})
 
     assert_kind_of Vonage::Response, verify2.cancel_verification_request(request_id: request_id)
+  end
+
+  def test_cancel_verification_request_method_with_basic_authentication
+    stub_request(:delete, cancel_request_uri).with(request(auth_method: basic_authorization)).to_return(status: 204, headers: {})
+
+    assert_kind_of Vonage::Response, verify2_with_basic_auth.cancel_verification_request(request_id: request_id)
   end
 
   def test_cancel_verification_request_method_without_request_id


### PR DESCRIPTION
This PR adds multi-authentication support to the Messages API and Verify API v2 product implementations. Specifically it:

- Defines a `BasicAndBearerToken` to encapsulate the auth logic for products that support both Basic and JWT authentication
- Updates the Messages and Verify implementations to use this new logic
- Adds new unit tests to cover the changes
- Adds a detailed Authentication section to the README