### PR TITLE
feat: Add Identity Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ need a Vonage account. Sign up [for free at vonage.com][signup].
     * [Verify API v2](#verify-api-v2)
     * [Voice API](#voice-api)
       * [NCCO Builder](#ncco-builder)
+    * [Identity Insights API](#identity-insights-api)
 * [Documentation](#documentation)
 * [Supported APIs](#supported-apis)
 * [Other SDKs and Tools](#other-sdks-and-tools)
@@ -937,6 +938,68 @@ response = client.voice.create({
 })
 ```
 
+## Identity Insights API
+
+The [Vonage Identity Insights API](https://developer.vonage.com/en/identity-insights/overview) provides real-time access to a broad range of attributes related to the carrier, subscriber, or device associated with a phone number. See the Vonage Developer Documentation for a [complete API reference](https://developer.vonage.com/en/api/identity-insights) listing all available insight types.
+
+> [!NOTE] 
+> The Vonage Ruby SDK currently supports the following insight types:
+>   - Format
+>   - Current Carrier
+>   - Original Carrier
+>   - SIM Swap
+
+Calling `identity_insights` on an instance of `Client` returns an `IdentityInsights` object which provides methods for interacting with the Identity Insights API.
+
+```ruby
+client.identity_insights # => #<Vonage::IdentityInsights>
+```
+
+### Making an Insights Request
+
+You can make an Identity Insights request by calling the `IdentityInsights#requests` method, for example:
+
+```ruby
+response = client.identity_insights.requests(phone_number: '447900000000', insights: { format: {} })
+```
+
+### Using the Insights Builder
+
+The `IdentityInsights` object implements a `insights_builder` method. This method returns an `InsightsBuilder` object:
+
+```ruby
+insights_builder = client.identity_insights.insights_builder # => #<Vonage::IdentityInsights::InsightsBuilder @insights={}>
+```
+
+You can then call various methods on the builder in order to add the insights that you require. Each of these methods returns the calling object, so the method invocations can be chained:
+
+```ruby
+insights_builder.add_format.add_current_carrier
+# => #<Vonage::IdentityInsights::InsightsBuilder @insights={:format=>{}, :current_carrier=>{}}>
+```
+
+The builder object can be passed into the `IdentityInsights#requests` method invocation as the value of the `insights` keyword argument:
+
+```ruby
+response = client.identity_insights.requests(phone_number: '447900000000', insights: insights_builder)
+```
+
+### Calling the Method with a Block
+
+The `IdentityInsights#requests` method can also be called with a block. The method yields an `InsightsBuilder` object to the block and expects an `InsightsBuilder` object to be returned by the block.
+
+```ruby
+response = client.identity_insights.requests(phone_number: '447900000000', purpose: "FraudPreventionAndDetection") do |builder|
+  builder.add_format
+    .add_original_carrier
+    .add_current_carrier
+    .add_sim_swap(period: 2400)
+end
+```
+
+> [!NOTE]
+> When requesting the SIM Swap insight, you should pass the `purpose` keyword argument to the `IdentityInsights#requests` method invocation with a value of `'FraudPreventionAndDetection'`.
+
 ## Documentation
 
 Vonage Ruby SDK documentation: https://www.rubydoc.info/gems/vonage
@@ -952,10 +1015,11 @@ The following is a list of Vonage APIs for which the Ruby SDK currently provides
 * [Account API](https://developer.vonage.com/en/account/overview)
 * [Application API](https://developer.vonage.com/en/application/overview)
 * [Conversation API](https://developer.vonage.com/en/conversation/overview)
-* [Meetings API](https://developer.vonage.com/en/meetings/overview)
+* [Identity Insights API](https://developer.vonage.com/en/identity-insights/overview)
+* [Meetings API](https://developer.vonage.com/en/meetings/overview) (deprecated)
 * [Messages API](https://developer.vonage.com/en/messages/overview)
-* [Network Number Verification API](https://developer.vonage.com/en/number-verification/overview)
-* [Network SIM Swap API](https://developer.vonage.com/en/sim-swap/overview)
+* [Network Number Verification API](https://developer.vonage.com/en/number-verification/overview) (deprecated)
+* [Network SIM Swap API](https://developer.vonage.com/en/sim-swap/overview) (deprecated)
 * [Number Insight API](https://developer.vonage.com/en/number-insight/overview)
 * [Numbers API](https://developer.vonage.com/en/numbers/overview)
 * [Proactive Connect API](https://developer.vonage.com/en/proactive-connect/overview) *

--- a/lib/vonage/client.rb
+++ b/lib/vonage/client.rb
@@ -70,6 +70,13 @@ module Vonage
       @files ||= T.let(Files.new(config), T.nilable(Vonage::Files))
     end
 
+    # @return [IdentityInsights]
+    #
+    sig { returns(T.nilable(Vonage::IdentityInsights)) }
+    def identity_insights
+      @identity_insights ||= T.let(IdentityInsights.new(config), T.nilable(Vonage::IdentityInsights))
+    end
+
     # @return [Meetings]
     # @deprecated
     sig { returns(T.nilable(Vonage::Meetings)) }

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Vonage
+  class IdentityInsights < Namespace
+  end
+end

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -12,6 +12,37 @@ module Vonage
     self.request_body = JSON
 
     # Submit an Identity Insights request.
+    #  The SDK currently supports the following insight types: `format`, `sim_swap`, `current_carrier`, and `previous_carrier`.
+    #
+    # @example with `insights` as a Hash
+    #   response = client.identity_insights.requests(phone_number: '447900000000', insights: { format: {} })
+    #
+    # @example with `insights` as an InsightsBuilder
+    #   insights = client.identity_insights.insights_builder.add_format.add_sim_swap(period: 180)
+    #   response = client.identity_insights.requests(phone_number: '447900000000', insights: insights)
+    #
+    # @example with a block to build `insights`
+    #   response = client.identity_insights.requests(phone_number: '447900000000') do |builder|
+    #     builder.add_format
+    #     builder.add_sim_swap(period: 180)
+    #   end
+    #
+    # @option params [required, String] :phone_number The phone number to request insights for, E.164 formatted.
+    #
+    # @option params [String] :purpose The purpose for requesting the insights.
+    #
+    # @option params [Hash, InsightsBuilder] :insights
+    #   A Hash or InsightsBuilder instance specifying the types of insights to request.
+    #   See the Vonage developer documentation for any parameters supported by each insight type.
+    #
+    # for block {|builder| ... }
+    # @yield [builder] passes a InsightsBuilder instance to the block
+    # @yieldreturn [required, InsightsBuilder] expects the block to return a InsightsBuilder instance
+    #
+    # @return [Vonage::Response] The API response.
+    #
+    # @see https://developer.vonage.com/en/api/identity-insights#getInsights
+    #
     def requests(phone_number:, insights: {}, **options)
       insights = yield insights_builder if block_given?
 
@@ -26,6 +57,9 @@ module Vonage
       request('/identity-insights/v1/requests', params: params, type: Post)
     end
 
+    # Instantiate an InsightsBuilder.
+    # @return [InsightsBuilder] A new InsightsBuilder instance.
+    #
     def insights_builder
       InsightsBuilder.new
     end

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -12,7 +12,7 @@ module Vonage
     self.request_body = JSON
 
     # Submit an Identity Insights request.
-    #  The SDK currently supports the following insight types: `format`, `sim_swap`, `current_carrier`, and `previous_carrier`.
+    #  The SDK currently supports the following insight types: `format`, `sim_swap`, `current_carrier`, and `original_carrier`.
     #
     # @example with `insights` as a Hash
     #   response = client.identity_insights.requests(phone_number: '447900000000', insights: { format: {} })
@@ -27,7 +27,7 @@ module Vonage
     #     builder.add_sim_swap(period: 180)
     #   end
     #
-    # @option params [required, String] :phone_number The phone number to request insights for, E.164 formatted.
+    # @option params [required, String] :phone_number The phone number to request insights for.
     #
     # @option params [String] :purpose The purpose for requesting the insights.
     #
@@ -45,8 +45,6 @@ module Vonage
     #
     def requests(phone_number:, insights: {}, **options)
       insights = yield insights_builder if block_given?
-
-      validate_phone_number(phone_number)
       validate_insights(insights)
 
       params = {
@@ -65,10 +63,6 @@ module Vonage
     end
 
     private
-
-    def validate_phone_number(phone_number)
-      raise ArgumentError.new("`phone_number` must be in E.164 format") unless Phonelib.parse(phone_number).valid?
-    end
 
     def validate_insights(insights)
       raise ArgumentError.new("`insights` must be a Hash or instance of InsightsBuilder") unless insights.is_a?(Hash) || insights.is_a?(InsightsBuilder)

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -13,17 +13,17 @@ module Vonage
 
     # Submit an Identity Insights request.
     def requests(phone_number:, insights: {}, **options)
-
+      insights = yield insights_builder if block_given?
       raise ArgumentError.new("`phone_number` must be in E.164 format") unless Phonelib.parse(phone_number).valid?
-      raise ArgumentError.new("`insights` must be a Hash or instance of InsightsBuilder") unless insights.is_a?(Hash)
+      raise ArgumentError.new("`insights` must be a Hash or instance of InsightsBuilder") unless insights.is_a?(Hash) || insights.is_a?(InsightsBuilder)
       raise ArgumentError.new("`insights` cannot be empty") if insights.to_h.empty?
 
-      invalid_insights = insights.keys - VALID_INSIGHT_TYPES
+      invalid_insights = insights.to_h.keys - VALID_INSIGHT_TYPES
       raise ArgumentError.new("`insights` contains the following invalid or unsupported insight types: #{invalid_insights.join(', ')}") unless invalid_insights.empty?
 
       params = {
         phone_number: phone_number,
-        insights: insights
+        insights: insights.to_h
       }.merge(options)
 
       request('/identity-insights/v1/requests', params: params, type: Post)

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -3,5 +3,30 @@
 
 module Vonage
   class IdentityInsights < Namespace
+    VALID_INSIGHT_TYPES = %i[format sim_swap original_carrier current_carrier].freeze
+    
+    self.authentication = BearerToken
+
+    self.host = :vonage_host
+
+    self.request_body = JSON
+
+    # Submit an Identity Insights request.
+    def requests(phone_number:, insights: {}, **options)
+
+      raise ArgumentError.new("`phone_number` must be in E.164 format") unless Phonelib.parse(phone_number).valid?
+      raise ArgumentError.new("`insights` must be a Hash or instance of InsightsBuilder") unless insights.is_a?(Hash)
+      raise ArgumentError.new("`insights` cannot be empty") if insights.to_h.empty?
+
+      invalid_insights = insights.keys - VALID_INSIGHT_TYPES
+      raise ArgumentError.new("`insights` contains the following invalid or unsupported types: #{invalid_insights.join(', ')}") unless invalid_insights.empty?
+
+      params = {
+        phone_number: phone_number,
+        insights: insights
+      }.merge(options)
+
+      request('/identity-insights/v1/requests', params: params, type: Post)
+    end
   end
 end

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -19,7 +19,7 @@ module Vonage
       raise ArgumentError.new("`insights` cannot be empty") if insights.to_h.empty?
 
       invalid_insights = insights.keys - VALID_INSIGHT_TYPES
-      raise ArgumentError.new("`insights` contains the following invalid or unsupported types: #{invalid_insights.join(', ')}") unless invalid_insights.empty?
+      raise ArgumentError.new("`insights` contains the following invalid or unsupported insight types: #{invalid_insights.join(', ')}") unless invalid_insights.empty?
 
       params = {
         phone_number: phone_number,
@@ -27,6 +27,10 @@ module Vonage
       }.merge(options)
 
       request('/identity-insights/v1/requests', params: params, type: Post)
+    end
+
+    def insights_builder
+      InsightsBuilder.new
     end
   end
 end

--- a/lib/vonage/identity_insights.rb
+++ b/lib/vonage/identity_insights.rb
@@ -14,12 +14,9 @@ module Vonage
     # Submit an Identity Insights request.
     def requests(phone_number:, insights: {}, **options)
       insights = yield insights_builder if block_given?
-      raise ArgumentError.new("`phone_number` must be in E.164 format") unless Phonelib.parse(phone_number).valid?
-      raise ArgumentError.new("`insights` must be a Hash or instance of InsightsBuilder") unless insights.is_a?(Hash) || insights.is_a?(InsightsBuilder)
-      raise ArgumentError.new("`insights` cannot be empty") if insights.to_h.empty?
 
-      invalid_insights = insights.to_h.keys - VALID_INSIGHT_TYPES
-      raise ArgumentError.new("`insights` contains the following invalid or unsupported insight types: #{invalid_insights.join(', ')}") unless invalid_insights.empty?
+      validate_phone_number(phone_number)
+      validate_insights(insights)
 
       params = {
         phone_number: phone_number,
@@ -31,6 +28,20 @@ module Vonage
 
     def insights_builder
       InsightsBuilder.new
+    end
+
+    private
+
+    def validate_phone_number(phone_number)
+      raise ArgumentError.new("`phone_number` must be in E.164 format") unless Phonelib.parse(phone_number).valid?
+    end
+
+    def validate_insights(insights)
+      raise ArgumentError.new("`insights` must be a Hash or instance of InsightsBuilder") unless insights.is_a?(Hash) || insights.is_a?(InsightsBuilder)
+      raise ArgumentError.new("`insights` cannot be empty") if insights.to_h.empty?
+
+      invalid_insights = insights.to_h.keys - VALID_INSIGHT_TYPES
+      raise ArgumentError.new("`insights` contains the following invalid or unsupported insight types: #{invalid_insights.join(', ')}") unless invalid_insights.empty?
     end
   end
 end

--- a/lib/vonage/identity_insights/insights_builder.rb
+++ b/lib/vonage/identity_insights/insights_builder.rb
@@ -9,18 +9,28 @@ module Vonage
 
     def add_format
       @insights[:format] = {}
+      self
     end
 
-    def add_sim_swap
-      @insights[:sim_swap] = {}
+    def add_sim_swap(period: nil)
+      params = {}
+      if period
+        raise ArgumentError, 'Period must be an Integer' unless period.is_a?(Integer)
+        raise ArgumentError, 'Period must be between 1 and 2400' unless period.between?(1, 2400)
+        params[:period] = period 
+      end
+      @insights[:sim_swap] = params
+      self
     end
 
     def add_current_carrier
       @insights[:current_carrier] = {}
+      self
     end
 
     def add_previous_carrier
       @insights[:previous_carrier] = {}
+      self
     end
 
     def to_h

--- a/lib/vonage/identity_insights/insights_builder.rb
+++ b/lib/vonage/identity_insights/insights_builder.rb
@@ -47,14 +47,14 @@ module Vonage
       self
     end
 
-    # Add a Previous Carrier insight.
+    # Add an Original Carrier insight.
     # @example
     #   builder = Vonage::IdentityInsights::InsightsBuilder.new
-    #   builder.add_previous_carrier
+    #   builder.add_original_carrier
     # @return [InsightsBuilder] The InsightsBuilder instance.
     #
-    def add_previous_carrier
-      @insights[:previous_carrier] = {}
+    def add_original_carrier
+      @insights[:original_carrier] = {}
       self
     end
 

--- a/lib/vonage/identity_insights/insights_builder.rb
+++ b/lib/vonage/identity_insights/insights_builder.rb
@@ -7,11 +7,25 @@ module Vonage
       @insights = {}
     end
 
+    # Add a Format insight.
+    # @example
+    #   builder = Vonage::IdentityInsights::InsightsBuilder.new
+    #   builder.add_format
+    # @return [InsightsBuilder] The InsightsBuilder instance.
+    #
     def add_format
       @insights[:format] = {}
       self
     end
 
+    # Add a Sim Swap insight.
+    # @example
+    #   builder = Vonage::IdentityInsights::InsightsBuilder.new
+    #   builder.add_sim_swap(period: 180)
+    # @param period [Integer] The period for the sim swap insight.
+    #   - Optional. If provided, must be between 1 and 2400.
+    # @return [InsightsBuilder] The InsightsBuilder instance.
+    #
     def add_sim_swap(period: nil)
       params = {}
       if period
@@ -22,16 +36,31 @@ module Vonage
       self
     end
 
+    # Add a Current Carrier insight.
+    # @example
+    #   builder = Vonage::IdentityInsights::InsightsBuilder.new
+    #   builder.add_current_carrier
+    # @return [InsightsBuilder] The InsightsBuilder instance.
+    #
     def add_current_carrier
       @insights[:current_carrier] = {}
       self
     end
 
+    # Add a Previous Carrier insight.
+    # @example
+    #   builder = Vonage::IdentityInsights::InsightsBuilder.new
+    #   builder.add_previous_carrier
+    # @return [InsightsBuilder] The InsightsBuilder instance.
+    #
     def add_previous_carrier
       @insights[:previous_carrier] = {}
       self
     end
 
+    # Convert the InsightsBuilder to a Hash.
+    # @return [Hash] The insights as a Hash.
+    #
     def to_h
       @insights
     end

--- a/lib/vonage/identity_insights/insights_builder.rb
+++ b/lib/vonage/identity_insights/insights_builder.rb
@@ -15,8 +15,7 @@ module Vonage
     def add_sim_swap(period: nil)
       params = {}
       if period
-        raise ArgumentError, 'Period must be an Integer' unless period.is_a?(Integer)
-        raise ArgumentError, 'Period must be between 1 and 2400' unless period.between?(1, 2400)
+        validate_sim_swap_period(period)
         params[:period] = period 
       end
       @insights[:sim_swap] = params
@@ -35,6 +34,13 @@ module Vonage
 
     def to_h
       @insights
+    end
+
+    private
+
+    def validate_sim_swap_period(period)
+      raise ArgumentError, 'Period must be an Integer' unless period.is_a?(Integer)
+      raise ArgumentError, 'Period must be between 1 and 2400' unless period.between?(1, 2400)
     end
   end
 end

--- a/lib/vonage/identity_insights/insights_builder.rb
+++ b/lib/vonage/identity_insights/insights_builder.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+module Vonage
+  class IdentityInsights::InsightsBuilder
+    def initialize
+      @insights = {}
+    end
+
+    def add_format
+      @insights[:format] = {}
+    end
+
+    def add_sim_swap
+      @insights[:sim_swap] = {}
+    end
+
+    def add_current_carrier
+      @insights[:current_carrier] = {}
+    end
+
+    def add_previous_carrier
+      @insights[:previous_carrier] = {}
+    end
+
+    def to_h
+      @insights
+    end
+  end
+end

--- a/test/vonage/client_test.rb
+++ b/test/vonage/client_test.rb
@@ -42,6 +42,10 @@ class Vonage::ClientTest < Vonage::Test
     assert_kind_of Vonage::Files, client.files
   end
 
+  def test_identity_insights_method
+    assert_kind_of Vonage::IdentityInsights, client.identity_insights
+  end
+
   def test_meetings_method
     assert_kind_of Vonage::Meetings, client.meetings
   end

--- a/test/vonage/identity_insights_test.rb
+++ b/test/vonage/identity_insights_test.rb
@@ -111,4 +111,37 @@ class Vonage::IdentityInsightsTest < Vonage::Test
   def test_insights_builder_method
     assert_kind_of Vonage::IdentityInsights::InsightsBuilder, identity_insights.insights_builder
   end
+
+  def test_requests_method_with_insights_builder
+    params = {
+      phone_number: phone_number,
+      insights: {
+        format: {}
+      }
+    }
+    
+    builder = identity_insights.insights_builder
+    builder.add_format
+
+    stub_request(:post, identity_insights_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, identity_insights.requests(phone_number: phone_number, insights: builder)
+  end
+
+  def test_requests_method_with_a_block
+    params = {
+      phone_number: phone_number,
+      insights: {
+        format: {}
+      }
+    }
+
+    stub_request(:post, identity_insights_uri).with(request(body: params)).to_return(response)
+
+    response = identity_insights.requests(phone_number: phone_number) do |builder|
+      builder.add_format
+    end
+
+    assert_kind_of Vonage::Response, response
+  end
 end

--- a/test/vonage/identity_insights_test.rb
+++ b/test/vonage/identity_insights_test.rb
@@ -107,4 +107,8 @@ class Vonage::IdentityInsightsTest < Vonage::Test
   def test_requests_method_with_invalid_insights_type
     assert_raises(ArgumentError) { identity_insights.requests(phone_number: phone_number, insights: { foo: {} }) }
   end
+
+  def test_insights_builder_method
+    assert_kind_of Vonage::IdentityInsights::InsightsBuilder, identity_insights.insights_builder
+  end
 end

--- a/test/vonage/identity_insights_test.rb
+++ b/test/vonage/identity_insights_test.rb
@@ -92,10 +92,6 @@ class Vonage::IdentityInsightsTest < Vonage::Test
     assert_raises(ArgumentError) { identity_insights.requests(insights: { format: {} }) }
   end
 
-  def test_requests_method_with_invalid_phone_number
-    assert_raises(ArgumentError) { identity_insights.requests(phone_number: '0000000000000', insights: { format: {} }) }
-  end
-
   def test_requests_method_with_empty_insights
     assert_raises(ArgumentError) { identity_insights.requests(phone_number: phone_number) }
   end

--- a/test/vonage/identity_insights_test.rb
+++ b/test/vonage/identity_insights_test.rb
@@ -1,0 +1,110 @@
+# typed: false
+require_relative './test'
+
+class Vonage::IdentityInsightsTest < Vonage::Test
+  def identity_insights
+    Vonage::IdentityInsights.new(config)
+  end
+
+  def geospecific_identity_insights
+    config = Vonage::Config.new.merge(
+      {
+        application_id: application_id,
+        private_key: private_key,
+        vonage_host: 'api-us.vonage.com'
+      }
+    )
+
+    Vonage::IdentityInsights.new(config)
+  end
+
+  def default_host
+    'https://api-eu.vonage.com'
+  end
+
+  def geospecific_host
+    'https://api-us.vonage.com'
+  end
+
+  def product_path
+    '/identity-insights/v1/requests'
+  end
+
+  def identity_insights_uri
+    default_host + product_path
+  end
+
+  def geospecific_identity_insights_uri
+    geospecific_host + product_path
+  end
+
+  def phone_number
+    '447900000000'
+  end
+
+  def test_requests_method
+    params = {
+      phone_number: phone_number,
+      insights: {
+        format: {}
+      }
+    }
+
+    stub_request(:post, identity_insights_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, identity_insights.requests(phone_number: phone_number, insights: { format: {} })
+  end
+
+  def test_requests_method_with_optional_parameters
+    params = {
+      phone_number: phone_number,
+      purpose: 'FraudPreventionAndDetection',
+      insights: {
+        sim_swap: {}
+      }
+    }
+
+    stub_request(:post, identity_insights_uri).with(request(body: params)).to_return(response)
+
+    response = identity_insights.requests(
+      phone_number: phone_number,
+      purpose: 'FraudPreventionAndDetection',
+      insights: { sim_swap: {} }
+    )
+
+    assert_kind_of Vonage::Response, response
+  end
+
+  def test_requests_method_with_geospecific_host
+    params = {
+      phone_number: phone_number,
+      insights: {
+        format: {}
+      }
+    }
+
+    stub_request(:post, geospecific_identity_insights_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, geospecific_identity_insights.requests(phone_number: phone_number, insights: { format: {} })
+  end
+
+  def test_requests_method_without_phone_number
+    assert_raises(ArgumentError) { identity_insights.requests(insights: { format: {} }) }
+  end
+
+  def test_requests_method_with_invalid_phone_number
+    assert_raises(ArgumentError) { identity_insights.requests(phone_number: '0000000000000', insights: { format: {} }) }
+  end
+
+  def test_requests_method_with_empty_insights
+    assert_raises(ArgumentError) { identity_insights.requests(phone_number: phone_number) }
+  end
+
+  def test_requests_method_with_invalid_insights_class
+    assert_raises(ArgumentError) { identity_insights.requests(phone_number: phone_number, insights: ['format']) }
+  end
+
+  def test_requests_method_with_invalid_insights_type
+    assert_raises(ArgumentError) { identity_insights.requests(phone_number: phone_number, insights: { foo: {} }) }
+  end
+end

--- a/test/vonage/insights_builder/insights_builder_test.rb
+++ b/test/vonage/insights_builder/insights_builder_test.rb
@@ -52,10 +52,10 @@ class Vonage::IdentityInsights::InsightsBuilderTest < Vonage::Test
     assert_equal expected, builder.to_h
   end
 
-  def test_add_previous_carrier_method
-    expected = {previous_carrier: {}}
+  def test_add_original_carrier_method
+    expected = {original_carrier: {}}
     builder = identity_insights.insights_builder
-    builder.add_previous_carrier
+    builder.add_original_carrier
 
     assert_equal expected, builder.to_h
   end
@@ -65,13 +65,13 @@ class Vonage::IdentityInsights::InsightsBuilderTest < Vonage::Test
       format: {},
       sim_swap: {},
       current_carrier: {},
-      previous_carrier: {}
+      original_carrier: {}
     }
     builder = identity_insights.insights_builder
     builder.add_format
     builder.add_sim_swap
     builder.add_current_carrier
-    builder.add_previous_carrier
+    builder.add_original_carrier
 
     assert_equal expected, builder.to_h
   end
@@ -81,13 +81,13 @@ class Vonage::IdentityInsights::InsightsBuilderTest < Vonage::Test
       format: {},
       sim_swap: {},
       current_carrier: {},
-      previous_carrier: {}
+      original_carrier: {}
     }
     builder = identity_insights.insights_builder
     builder.add_format
       .add_sim_swap
       .add_current_carrier
-      .add_previous_carrier
+      .add_original_carrier
     
     assert_equal expected, builder.to_h
   end

--- a/test/vonage/insights_builder/insights_builder_test.rb
+++ b/test/vonage/insights_builder/insights_builder_test.rb
@@ -1,0 +1,45 @@
+# typed: false
+
+class Vonage::IdentityInsights::InsightsBuilderTest < Vonage::Test
+  def identity_insights
+    Vonage::IdentityInsights.new(config)
+  end
+
+  def test_add_format_method
+    expected = {format: {}}
+    builder = identity_insights.insights_builder
+    builder.add_format
+
+    assert_equal expected, builder.to_h
+  end
+
+  def test_add_sim_swap_method
+    expected = {sim_swap: {}}
+    builder = identity_insights.insights_builder
+    builder.add_sim_swap
+
+    assert_equal expected, builder.to_h
+  end
+
+  def test_add_current_carrier_method
+    expected = {current_carrier: {}}
+    builder = identity_insights.insights_builder
+    builder.add_current_carrier
+
+    assert_equal expected, builder.to_h
+  end
+
+  def test_add_previous_carrier_method
+    expected = {previous_carrier: {}}
+    builder = identity_insights.insights_builder
+    builder.add_previous_carrier
+
+    assert_equal expected, builder.to_h
+  end
+
+  def test_to_h_method
+    builder = identity_insights.insights_builder
+
+    assert_instance_of(Hash, builder.to_h)
+  end
+end

--- a/test/vonage/insights_builder/insights_builder_test.rb
+++ b/test/vonage/insights_builder/insights_builder_test.rb
@@ -21,6 +21,29 @@ class Vonage::IdentityInsights::InsightsBuilderTest < Vonage::Test
     assert_equal expected, builder.to_h
   end
 
+  def test_add_sim_swap_method_with_period
+    expected = {sim_swap: { period: 300 }}
+    builder = identity_insights.insights_builder
+    builder.add_sim_swap(period: 300)
+
+    assert_equal expected, builder.to_h
+  end
+
+  def test_add_sim_swap_method_with_invalid_period_type
+    builder = identity_insights.insights_builder
+    assert_raises(ArgumentError) { builder.add_sim_swap(period: 'three_hundred') }
+  end
+
+  def test_add_sim_swap_method_with_invalid_period_range_too_low
+    builder = identity_insights.insights_builder
+    assert_raises(ArgumentError) { builder.add_sim_swap(period: 0) }
+  end
+
+  def test_add_sim_swap_method_with_invalid_period_range_too_high
+    builder = identity_insights.insights_builder
+    assert_raises(ArgumentError) { builder.add_sim_swap(period: 2401) }
+  end
+
   def test_add_current_carrier_method
     expected = {current_carrier: {}}
     builder = identity_insights.insights_builder
@@ -34,6 +57,38 @@ class Vonage::IdentityInsights::InsightsBuilderTest < Vonage::Test
     builder = identity_insights.insights_builder
     builder.add_previous_carrier
 
+    assert_equal expected, builder.to_h
+  end
+
+  def test_adding_multiple_insights
+    expected = {
+      format: {},
+      sim_swap: {},
+      current_carrier: {},
+      previous_carrier: {}
+    }
+    builder = identity_insights.insights_builder
+    builder.add_format
+    builder.add_sim_swap
+    builder.add_current_carrier
+    builder.add_previous_carrier
+
+    assert_equal expected, builder.to_h
+  end
+
+  def test_adding_multiple_insights_with_method_chaining
+    expected = {
+      format: {},
+      sim_swap: {},
+      current_carrier: {},
+      previous_carrier: {}
+    }
+    builder = identity_insights.insights_builder
+    builder.add_format
+      .add_sim_swap
+      .add_current_carrier
+      .add_previous_carrier
+    
     assert_equal expected, builder.to_h
   end
 

--- a/test/vonage/network_sim_swap_test.rb
+++ b/test/vonage/network_sim_swap_test.rb
@@ -60,8 +60,8 @@ class Vonage::NetworkSIMSwapTest < Vonage::Test
 
   def test_check_method_with_invalid_phone_number
     assert_raises(TypeError) { network_sim_swap.check(phone_number: 447904603505) }
-    assert_raises(ArgumentError) { network_sim_swap.check(phone_number: '07904603505') }
-    assert_raises(ArgumentError) { network_sim_swap.check(phone_number: '447904603505') }
+    assert_raises(ArgumentError) { network_sim_swap.check(phone_number: '07000000000') }
+    assert_raises(ArgumentError) { network_sim_swap.check(phone_number: '447000000000') }
   end
 
   def test_check_method_with_invalid_max_age
@@ -95,7 +95,7 @@ class Vonage::NetworkSIMSwapTest < Vonage::Test
 
   def test_retrieve_date_method_with_invalid_phone_number
     assert_raises(TypeError) { network_sim_swap.retrieve_date(phone_number: 447904603505) }
-    assert_raises(ArgumentError) { network_sim_swap.retrieve_date(phone_number: '07904603505') }
-    assert_raises(ArgumentError) { network_sim_swap.retrieve_date(phone_number: '447904603505') }
+    assert_raises(ArgumentError) { network_sim_swap.retrieve_date(phone_number: '07000000000') }
+    assert_raises(ArgumentError) { network_sim_swap.retrieve_date(phone_number: '447000000000') }
   end
 end

--- a/test/vonage/verify2/templates_test.rb
+++ b/test/vonage/verify2/templates_test.rb
@@ -113,12 +113,6 @@ class Vonage::Verify2::TemplatesTest < Vonage::Test
     assert_kind_of Vonage::Response, templates.delete(template_id: template_id)
   end
 
-  def test_delete_method
-    stub_request(:delete, template_uri).to_return(response)
-
-    assert_kind_of Vonage::Response, templates.delete(template_id: template_id)
-  end
-
   def test_delete_method_with_basic_authentication
     stub_request(:delete, template_uri).with(request(auth_method: basic_authorization)).to_return(response)
 


### PR DESCRIPTION
This PR implements the Identity Insights API in the Ruby SDK. Specifically it:

- Defines an `IdentityInsights` class with a `requests` instance method to make Identity Insights requests
- Defines an `IdentityInsights::InsightsBuilder` class with methods to add required insights to the request
- Update the `Client` class to add an `identity insights` instance method which returns an `IdentityInsights` object
- Adds unit tests to cover the new functionality
- Does some tidy up of existing test files not related to Identity Insights