### PR TITLE
feat: Messages API Updates Apr 2026

### DIFF
--- a/test/vonage/messaging/channels/mms_test.rb
+++ b/test/vonage/messaging/channels/mms_test.rb
@@ -130,4 +130,10 @@ class Vonage::Messaging::Channels::MMSTest < Vonage::Test
 
     assert_equal 'abc123', mms.data[:client_ref]
   end
+
+  def test_with_trusted_recipient_parameter
+    mms = Vonage::Messaging::Channels::MMS.new(type: 'image', message: { url: 'https://example.com/image.jpg' }, opts: { trusted_recipient: true })
+
+    assert_equal true, mms.data[:trusted_recipient]
+  end
 end

--- a/test/vonage/messaging/channels/rcs_test.rb
+++ b/test/vonage/messaging/channels/rcs_test.rb
@@ -502,4 +502,10 @@ class Vonage::Messaging::Channels::RCSTest < Vonage::Test
     assert_includes rcs.data, :to
     assert_includes rcs.data, :from
   end
+
+  def test_with_trusted_recipient_parameter
+    rcs = Vonage::Messaging::Channels::RCS.new(type: 'text', message: 'Hello world!', opts: { trusted_recipient: true })
+
+    assert_equal true, rcs.data[:trusted_recipient]
+  end
 end

--- a/test/vonage/messaging/channels/sms_test.rb
+++ b/test/vonage/messaging/channels/sms_test.rb
@@ -72,4 +72,10 @@ class Vonage::Messaging::Channels::SMSTest < Vonage::Test
 
     assert_equal 'abc123', sms.data[:client_ref]
   end
+
+  def test_with_trusted_recipient_parameter
+    sms = Vonage::Messaging::Channels::SMS.new(type: 'text', message: 'Hello world!', opts: { trusted_recipient: true })
+
+    assert_equal true, sms.data[:trusted_recipient]
+  end
 end

--- a/test/vonage/messaging_test.rb
+++ b/test/vonage/messaging_test.rb
@@ -231,6 +231,12 @@ class Vonage::MessagingTest < Vonage::Test
     assert_kind_of Vonage::Response, geo_specific_messaging.update(message_uuid: message_uuid, status: 'read')
   end
 
+  def test_update_method_with_replying_indicator
+    stub_request(:patch, 'https://' + geo_specific_messaging_host + '/v1/messages/' + message_uuid).with(request(body: {status: 'read', replying_indicator: {show: true, type: 'text'}})).to_return(response)
+
+    assert_kind_of Vonage::Response, geo_specific_messaging.update(message_uuid: message_uuid, status: 'read', replying_indicator: {show: true, type: 'text'})
+  end
+
   # The below tests are to ensure backwards compatibility with the previous send method implementation
 
   def test_send_method_with_builder_setting_to_and_from


### PR DESCRIPTION
This PR adds unit tests to confirm support for the following Messages API features:

- The `trusted_recipient` parameter for SMS, MMS, and RCS message types
- The `replying_indicator` param for the `update` method