### PR TITLE
feat: Voice API Updates Apr 2026

### DIFF
--- a/lib/vonage/voice/actions/connect.rb
+++ b/lib/vonage/voice/actions/connect.rb
@@ -206,6 +206,7 @@ module Vonage
       }
 
       hash.merge!(headers: endpoint_attrs[:headers]) if endpoint_attrs[:headers]
+      hash.merge!(authorization: endpoint_attrs[:authorization]) if endpoint_attrs[:authorization]
 
       hash
     end

--- a/lib/vonage/voice/actions/input.rb
+++ b/lib/vonage/voice/actions/input.rb
@@ -85,6 +85,13 @@ module Vonage
       if self.speech[:maxDuration]
         raise ClientError.new("Expected 'maxDuration' to not be more than 60 seconds") unless self.speech[:maxDuration] <= 60 && self.speech[:maxDuration] >= 0
       end
+
+      if self.speech[:provider]
+        valid_providers = ['google']
+
+        raise ClientError.new("Invalid 'provider' value, must be one of: #{valid_providers.join(', ')}") unless valid_providers.include?(self.speech[:provider])
+        raise ClientError.new("The `providerOptions` parameter is required when specifying a `provider`") unless self.speech[:providerOptions]
+      end
     end
 
     def validate_event_url

--- a/lib/vonage/voice/actions/talk.rb
+++ b/lib/vonage/voice/actions/talk.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 module Vonage
   class Voice::Actions::Talk
-    attr_accessor :text, :bargeIn, :loop, :level, :language, :style, :premium
+    attr_accessor :text, :bargeIn, :loop, :level, :language, :style, :premium, :provider, :providerOptions
 
     def initialize(attributes= {})
       @text = attributes.fetch(:text)
@@ -12,6 +12,8 @@ module Vonage
       @language = attributes.fetch(:language, nil)
       @style = attributes.fetch(:style, nil)
       @premium = attributes.fetch(:premium, nil)
+      @provider = attributes.fetch(:provider, nil)
+      @providerOptions = attributes.fetch(:providerOptions, nil)
 
       after_initialize!
     end
@@ -36,6 +38,10 @@ module Vonage
       if self.premium || self.premium == false
         verify_premium
       end
+
+      if self.provider
+        verify_provider
+      end
     end
 
     def verify_barge_in
@@ -58,6 +64,13 @@ module Vonage
       raise ClientError.new("Expected 'premium' value to be a Boolean") unless self.premium == true || self.premium == false
     end
 
+    def verify_provider
+      valid_providers = ['google']
+
+      raise ClientError.new("Invalid 'provider' value, must be one of: #{valid_providers.join(', ')}") unless valid_providers.include?(self.provider)
+      raise ClientError.new("The `providerOptions` parameter is required when specifying a `provider`") unless self.providerOptions
+    end
+
     def action
       create_talk!(self)
     end
@@ -75,7 +88,9 @@ module Vonage
       ncco[0].merge!(level: builder.level) if builder.level
       ncco[0].merge!(language: builder.language) if builder.language
       ncco[0].merge!(style: builder.style) if builder.style
-      ncco[0].merge!(premium: builder.premium) if (builder.bargeIn || builder.bargeIn == false)
+      ncco[0].merge!(premium: builder.premium) if (builder.premium || builder.premium == false)
+      ncco[0].merge!(provider: builder.provider) if builder.provider
+      ncco[0].merge!(providerOptions: builder.providerOptions) if builder.providerOptions
 
       ncco
     end

--- a/test/vonage/voice/actions/connect_test.rb
+++ b/test/vonage/voice/actions/connect_test.rb
@@ -81,6 +81,20 @@ class Vonage::Voice::Actions::ConnectTest < Vonage::Test
     assert_match "Expected 'content-type' parameter to be either 'audio/l16;rate=16000', 'audio/l16;rate=8000', or 'audio/l16;rate=24000'", exception.message
   end
 
+  def test_create_endpoint_with_websocket_with_vonage_authorization_header
+    expected = { type: 'websocket', uri: 'wss://example.com/socket', :'content-type' => 'audio/l16;rate=8000', authorization: { type: 'vonage' } }
+    connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'websocket', uri: 'wss://example.com/socket', :'content-type' => 'audio/l16;rate=8000', authorization: { type: 'vonage' } })
+
+    assert_equal expected, connect.create_endpoint(connect)
+  end
+
+  def test_create_endpoint_with_websocket_with_custom_authorization_header
+    expected = { type: 'websocket', uri: 'wss://example.com/socket', :'content-type' => 'audio/l16;rate=8000', authorization: { type: 'custom', value: 'Bearer abc123def456ghi789' } }
+    connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'websocket', uri: 'wss://example.com/socket', :'content-type' => 'audio/l16;rate=8000', authorization: { type: 'custom', value: 'Bearer abc123def456ghi789' } })
+
+    assert_equal expected, connect.create_endpoint(connect)
+  end
+
   def test_create_endpoint_with_sip_uri
     expected = { type: 'sip', uri: 'sip:joe@domain.com' }
     connect = Vonage::Voice::Actions::Connect.new(endpoint: { type: 'sip', uri: 'sip:joe@domain.com' })

--- a/test/vonage/voice/actions/input_test.rb
+++ b/test/vonage/voice/actions/input_test.rb
@@ -38,7 +38,9 @@ class Vonage::Voice::Actions::InputTest < Vonage::Test
           startTimeout: 5,
           maxDuration: 50,
           saveAudio: true,
-          sensitivity: 50
+          sensitivity: 50,
+          provider: "google",
+          providerOptions: {}
         },
         eventUrl: [
           'https://example.com/webhooks/events',
@@ -67,7 +69,9 @@ class Vonage::Voice::Actions::InputTest < Vonage::Test
         startTimeout: 5,
         maxDuration: 50,
         saveAudio: true,
-        sensitivity: 50
+        sensitivity: 50,
+        provider: "google",
+        providerOptions: {}
       },
       eventUrl: [
         'https://example.com/webhooks/events',
@@ -149,6 +153,18 @@ class Vonage::Voice::Actions::InputTest < Vonage::Test
     exception = assert_raises { Vonage::Voice::Actions::Input.new(type: ['speech'], speech: { maxDuration: 62 }) }
 
     assert_match "Expected 'maxDuration' to not be more than 60 seconds", exception.message
+  end
+
+  def test_input_with_invalid_speech_provider_value
+    exception = assert_raises { Vonage::Voice::Actions::Input.new(type: ['speech'], speech: { provider: 'foo', providerOptions: {} }) }
+
+    assert_match "Invalid 'provider' value, must be one of: google", exception.message
+  end
+
+  def test_input_with_provider_but_no_provider_options
+    exception = assert_raises { Vonage::Voice::Actions::Input.new(type: ['speech'], speech: { provider: 'google' }) }
+
+    assert_match "The `providerOptions` parameter is required when specifying a `provider`", exception.message
   end
 
   def test_input_with_invalid_event_url_type

--- a/test/vonage/voice/actions/talk_test.rb
+++ b/test/vonage/voice/actions/talk_test.rb
@@ -26,7 +26,9 @@ class Vonage::Voice::Actions::TalkTest < Vonage::Test
         level: 0.5,
         language: 'en-GB',
         style: 1,
-        premium: true
+        premium: true,
+        provider: "google",
+        providerOptions: {}
       }
     ]
 
@@ -37,7 +39,9 @@ class Vonage::Voice::Actions::TalkTest < Vonage::Test
       level: 0.5,
       language: 'en-GB',
       style: 1,
-      premium: true
+      premium: true,
+      provider: "google",
+      providerOptions: {}
     )
 
     assert_equal expected, talk.create_talk!(talk)
@@ -71,5 +75,17 @@ class Vonage::Voice::Actions::TalkTest < Vonage::Test
     exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', premium: 'foo' }) }
 
     assert_match "Expected 'premium' value to be a Boolean", exception.message
+  end
+
+  def test_talk_with_invalid_provider_value
+    exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', provider: 'foo', providerOptions: {} }) }
+
+    assert_match "Invalid 'provider' value, must be one of: google", exception.message
+  end
+
+  def test_talk_with_provider_but_no_provider_options
+    exception = assert_raises { Vonage::Voice::Actions::Talk.new({ text: 'Sample Text', provider: 'google' }) }
+
+    assert_match "The `providerOptions` parameter is required when specifying a `provider`", exception.message
   end
 end

--- a/test/vonage/voice_test.rb
+++ b/test/vonage/voice_test.rb
@@ -68,6 +68,67 @@ class Vonage::VoiceTest < Vonage::Test
     assert_kind_of Vonage::Response, calls.create(params)
   end
 
+  def test_create_method_with_connect_to_websocket
+    params = {
+      to: [
+        {
+          type: 'websocket',
+          uri: 'wss://example.com/socket',
+          :'Content-Type' => 'audio/l16;rate=16000'
+        }
+      ],
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+
+    stub_request(:post, calls_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, calls.create(params)
+  end
+
+  def test_create_method_with_connect_to_websocket_with_vonage_authorization_header
+    params = {
+      to: [
+        {
+          type: 'websocket',
+          uri: 'wss://example.com/socket',
+          :'Content-Type' => 'audio/l16;rate=16000',
+          authorization: {
+            type: 'vonage'
+          }
+        }
+      ],
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+
+    stub_request(:post, calls_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, calls.create(params)
+  end
+
+  def test_create_method_with_connect_to_websocket_with_custom_authorization_header
+    params = {
+      to: [
+        {
+          type: 'websocket',
+          uri: 'wss://example.com/socket',
+          :'Content-Type' => 'audio/l16;rate=16000',
+          authorization: {
+            type: 'custom',
+            value: 'Bearer abc123def456ghi789'
+          }
+        }
+      ],
+      from: {type: 'phone', number: '14843335555'},
+      answer_url: ['https://example.com/answer']
+    }
+
+    stub_request(:post, calls_uri).with(request(body: params)).to_return(response)
+
+    assert_kind_of Vonage::Response, calls.create(params)
+  end
+
   def test_create_method_raises_error_if_from_set_and_random_from_number_true
     params = {
       to: [{type: 'phone', number: '14843331234'}],


### PR DESCRIPTION
This PR makes some small changes to the Voice API implementation. Specifically it:

- Adds support for setting `vonage` and `custom` authorization header in:
  - The `Voice#create` method
  - The `websocket` endpoint type of the `connect` NCCO
- Adds support for the `provider` and `providerOptions` params in:
  - The `talk` NCCO
  - The `speech` object of the `input` NCCO