### PR TITLE
feat: Add WhatsApp Zero Tap support to Verify v2

### DIFF
--- a/lib/vonage/verify2/channels/whats_app.rb
+++ b/lib/vonage/verify2/channels/whats_app.rb
@@ -24,6 +24,12 @@ module Vonage
       @from = from
     end
 
+    def mode=(mode)
+      valid_modes = ['otp_code', 'zero_tap']
+      raise ArgumentError, "Invalid 'mode' value #{mode}. Expected to be one of #{valid_modes.join(', ')}" unless valid_modes.include?(mode)
+      @mode = mode
+    end
+
     def to_h
       hash = Hash.new
       self.instance_variables.each do |ivar|

--- a/test/vonage/verify2/channels/whats_app_test.rb
+++ b/test/vonage/verify2/channels/whats_app_test.rb
@@ -65,6 +65,19 @@ class Vonage::Verify2::Channels::WhatsAppTest < Vonage::Test
     end
   end
 
+  def test_mode_setter_method
+    channel = whatsapp_channel
+    channel.mode = 'zero_tap'
+
+    assert_equal 'zero_tap', channel.instance_variable_get(:@mode)
+  end
+
+  def test_mode_setter_method_with_invalid_mode
+    assert_raises ArgumentError do
+      whatsapp_channel.mode = 'invalid_mode'
+    end
+  end
+
   def test_to_h_method
     channel_hash = Vonage::Verify2::Channels::WhatsApp.new(
       to: e164_compliant_number,


### PR DESCRIPTION
This PR adds support for the `mode` param to the WhatsApp channel of Verify v2