### PR TITLE
chore: Update Video Websocket `audio_rate` doc block 

### DIFF
--- a/lib/vonage/video/web_socket.rb
+++ b/lib/vonage/video/web_socket.rb
@@ -37,7 +37,7 @@ module Vonage
     #   - If you omit this property, all streams in the session will be included.
     # @option websocket [optional, Hash] :headers An object of key-value pairs of headers to be sent to your WebSocket server with each message, with a maximum length of 512 bytes.
     # @option websocket [optional, Integer] :audio_rate A number representing the audio sampling rate in Hz
-    #   - Must be one of: 8000, 16000
+    #   - Must be one of: 8000, 16000, 24000
     # @option websocket [optional, Boolean] :bidirectional Whether to send audio data from the WebSocket connection to a stream published in the session.
     #
     # @return [Response]


### PR DESCRIPTION
This PR updates the doc block for the Video API Websocket endpoint to specify `24000` as an option for the `audio_rate` param