### PR TITLE
feat: Add Base64 Audio Config to Video API Audio Connector implementation

### DIFF
--- a/lib/vonage/keys.rb
+++ b/lib/vonage/keys.rb
@@ -43,7 +43,8 @@ module Vonage
         'max_bitrate',
         'quantization_parameter',
         'has_transcription',
-        'transcription_properties'
+        'transcription_properties',
+        'audio_transport'
       ]
       hash.transform_keys do |k|
         if exceptions.include?(k.to_s)

--- a/lib/vonage/video/web_socket.rb
+++ b/lib/vonage/video/web_socket.rb
@@ -40,11 +40,11 @@ module Vonage
     #   - Must be one of: 8000, 16000, 24000
     # @option websocket [optional, Boolean] :bidirectional Whether to send audio data from the WebSocket connection to a stream published in the session.
     # @option websocket [optional, Hash] :audio_transport The configuration for the audio transport over the WebSocket connection.
-    # @option websocket [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
-    # @option websocket [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
-    # @option websocket [String] :audio_field (optional) The JSON key for the outbound audio data. The default value is "audio".
-    # @option websocket [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`.
-    # @option websocket [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
+    # @option websocket[:audio_transport] [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
+    # @option websocket[:audio_transport] [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
+    # @option websocket[:audio_transport] [String] :audio_field (optional) The JSON key for the outbound audio data. The default value is "audio".
+    # @option websocket[:audio_transport] [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`.
+    # @option websocket[:audio_transport] [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
     #
     # @return [Response]
     #

--- a/lib/vonage/video/web_socket.rb
+++ b/lib/vonage/video/web_socket.rb
@@ -39,6 +39,12 @@ module Vonage
     # @option websocket [optional, Integer] :audio_rate A number representing the audio sampling rate in Hz
     #   - Must be one of: 8000, 16000, 24000
     # @option websocket [optional, Boolean] :bidirectional Whether to send audio data from the WebSocket connection to a stream published in the session.
+    # @option websocket [optional, Hash] :audio_transport The configuration for the audio transport over the WebSocket connection.
+    # @option websocket [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
+    # @option websocket [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
+    # @option websocket [String] :audio_field (optional) The JSON key for the outbound audio data. The default value is "audio".
+    # @option websocket [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`.
+    # @option websocket [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
     #
     # @return [Response]
     #

--- a/test/vonage/video/web_socket_test.rb
+++ b/test/vonage/video/web_socket_test.rb
@@ -41,7 +41,16 @@ class Vonage::Video::WebSocketTest < Vonage::Test
         streams: ['stream1', 'stream2'],
         headers: { property1: 'foo', property2: 'bar' },
         audioRate: 16000,
-        bidirectional: true
+        bidirectional: true,
+        audioTransport: {
+          transport: 'json',
+          encoding: 'base64',
+          audio_field: 'audio',
+          receive_audio_field: 'audio',
+          static_fields: {
+            foo: 'bar'
+          }
+        }
       }
     }
 
@@ -55,7 +64,16 @@ class Vonage::Video::WebSocketTest < Vonage::Test
         streams: ['stream1', 'stream2'],
         headers: { property1: 'foo', property2: 'bar' },
         audio_rate: 16000,
-        bidirectional: true
+        bidirectional: true,
+        audio_transport: {
+          transport: 'json',
+          encoding: 'base64',
+          audio_field: 'audio',
+          receive_audio_field: 'audio',
+          static_fields: {
+            foo: 'bar'
+          }
+        }
       }
     )
 


### PR DESCRIPTION
This PR adds support for the `audio_transport` params within an Audio Connector Websocket configuration in the Video API implementation. Specifically it:

- Updates an existing unit test for the method to include the new params
- Updates the `camelcase` method of the `Keys` module to include the `audio_transport` param
- Updates the YARD doc comments for the method to include the new params

This PR completes https://jira.vonage.com/browse/DEVX-11291